### PR TITLE
Add tenant context and selection modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import Login from './pages/Login';
 import RouteGuard from './components/RouteGuard';
 import Patients from './pages/Patients';
@@ -25,196 +25,242 @@ import ProblemList from './pages/ProblemList';
 import LabOrdersPage from './pages/LabOrders';
 import LabOrderDetailPage from './pages/LabOrderDetail';
 import './styles/App.css';
+import { TenantProvider, useTenant } from './contexts/TenantContext';
+import TenantPicker from './components/TenantPicker';
+
+function TenantOverlays() {
+  const location = useLocation();
+  const { activeTenant, tenants, isLoading } = useTenant();
+
+  const isLoginRoute = location.pathname === '/login';
+  const showLoading = isLoading && !isLoginRoute;
+  const showTenantPicker = !isLoginRoute && !isLoading && tenants.length > 1 && !activeTenant;
+  const showNoTenants = !isLoginRoute && !isLoading && tenants.length === 0 && !activeTenant;
+
+  return (
+    <>
+      {showLoading && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/70">
+          <div className="rounded-xl bg-white px-6 py-4 text-sm font-medium text-slate-600 shadow-lg">
+            Loading clinics...
+          </div>
+        </div>
+      )}
+      {showTenantPicker && <TenantPicker />}
+      {showNoTenants && (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/70 px-6 text-center">
+          <div className="max-w-md rounded-2xl bg-white px-8 py-10 shadow-xl">
+            <h2 className="text-lg font-semibold text-slate-900">No clinics available</h2>
+            <p className="mt-3 text-sm text-slate-500">
+              Your account does not have any clinic memberships yet. Please contact your administrator to request access.
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function AppContent() {
+  return (
+    <>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/patients"
+          element={
+            <RouteGuard>
+              <Patients />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/patients/:id"
+          element={
+            <RouteGuard>
+              <PatientDetail />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/patients/:patientId/problems"
+          element={
+            <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin']}>
+              <ProblemList />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/appointments"
+          element={
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
+              <AppointmentsPage />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/appointments/new"
+          element={
+            <RouteGuard allowedRoles={['AdminAssistant']}>
+              <AppointmentForm />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/appointments/:id"
+          element={
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
+              <AppointmentDetail />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/patients/:id/visits/new"
+          element={
+            <RouteGuard>
+              <AddVisit />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <RouteGuard>
+              <Home />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/register"
+          element={
+            <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin']}>
+              <RegisterPatient />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/visits/:id"
+          element={
+            <RouteGuard>
+              <VisitDetail />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/cohort"
+          element={
+            <RouteGuard>
+              <Cohort />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/reports"
+          element={
+            <RouteGuard>
+              <Reports />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/lab-orders"
+          element={
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+              <LabOrdersPage />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/lab-orders/:labOrderId"
+          element={
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+              <LabOrderDetailPage />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/pharmacy/queue"
+          element={
+            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin']}>
+              <PharmacyQueue />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/pharmacy/inventory"
+          element={
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
+              <PharmacyInventory />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/pharmacy/drugs/new"
+          element={
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
+              <AddDrug />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/billing/workspace"
+          element={
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
+              <BillingWorkspace />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/billing/visit/:visitId"
+          element={
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
+              <VisitBilling />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/billing/pos"
+          element={
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin']}>
+              <PosList />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/pharmacy/dispense/:prescriptionId"
+          element={
+            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech']}>
+              <DispenseDetail />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <RouteGuard allowedRoles={['ITAdmin']}>
+              <Settings />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/settings/services"
+          element={
+            <RouteGuard allowedRoles={['ITAdmin']}>
+              <SettingsServices />
+            </RouteGuard>
+          }
+        />
+      </Routes>
+      <TenantOverlays />
+    </>
+  );
+}
 
 function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route
-        path="/patients"
-        element={
-          <RouteGuard>
-            <Patients />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/patients/:id"
-        element={
-          <RouteGuard>
-            <PatientDetail />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/patients/:patientId/problems"
-        element={
-          <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin']}>
-            <ProblemList />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/appointments"
-        element={
-          <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
-            <AppointmentsPage />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/appointments/new"
-        element={
-          <RouteGuard allowedRoles={['AdminAssistant']}>
-            <AppointmentForm />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/appointments/:id"
-        element={
-          <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
-            <AppointmentDetail />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/patients/:id/visits/new"
-        element={
-          <RouteGuard>
-            <AddVisit />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/"
-        element={
-          <RouteGuard>
-            <Home />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/register"
-        element={
-          <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin']}>
-            <RegisterPatient />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/visits/:id"
-        element={
-          <RouteGuard>
-            <VisitDetail />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/cohort"
-        element={
-          <RouteGuard>
-            <Cohort />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/reports"
-        element={
-          <RouteGuard>
-            <Reports />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/lab-orders"
-        element={
-          <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
-            <LabOrdersPage />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/lab-orders/:labOrderId"
-        element={
-          <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
-            <LabOrderDetailPage />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/pharmacy/queue"
-        element={
-          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin']}>
-            <PharmacyQueue />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/pharmacy/inventory"
-        element={
-          <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
-            <PharmacyInventory />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/pharmacy/drugs/new"
-        element={
-          <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
-            <AddDrug />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/billing/workspace"
-        element={
-          <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
-            <BillingWorkspace />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/billing/visit/:visitId"
-        element={
-          <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
-            <VisitBilling />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/billing/pos"
-        element={
-          <RouteGuard allowedRoles={['Cashier', 'ITAdmin']}>
-            <PosList />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/pharmacy/dispense/:prescriptionId"
-        element={
-          <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech']}>
-            <DispenseDetail />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/settings"
-        element={
-          <RouteGuard allowedRoles={['ITAdmin']}>
-            <Settings />
-          </RouteGuard>
-        }
-      />
-      <Route
-        path="/settings/services"
-        element={
-          <RouteGuard allowedRoles={['ITAdmin']}>
-            <SettingsServices />
-          </RouteGuard>
-        }
-      />
-    </Routes>
+    <TenantProvider>
+      <AppContent />
+    </TenantProvider>
   );
 }
 

--- a/client/src/components/TenantPicker.tsx
+++ b/client/src/components/TenantPicker.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { useTenant } from '../contexts/TenantContext';
+
+const placeholderLogo = (name: string) =>
+  name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+
+const TenantPicker: React.FC = () => {
+  const { tenants, activeTenant, setActiveTenant, isSwitching } = useTenant();
+  const [error, setError] = useState<string | null>(null);
+  const [pendingTenantId, setPendingTenantId] = useState<string | null>(null);
+
+  const shouldShow = tenants.length > 1 && !activeTenant;
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const handleSelect = async (tenantId: string) => {
+    setError(null);
+    setPendingTenantId(tenantId);
+    try {
+      await setActiveTenant(tenantId);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Unable to switch tenant. Please try again.');
+      }
+      setPendingTenantId(null);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-6 py-12">
+      <div className="w-full max-w-3xl rounded-2xl bg-white p-10 shadow-2xl">
+        <div className="mb-8 text-center">
+          <h2 className="text-2xl font-semibold text-slate-900">Choose your clinic</h2>
+          <p className="mt-2 text-sm text-slate-500">
+            Select which clinic you would like to work in for this session.
+          </p>
+        </div>
+        {error && (
+          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        <div className="grid gap-4 md:grid-cols-2">
+          {tenants.map((tenant) => {
+            const initials = placeholderLogo(tenant.name);
+            const isPending = pendingTenantId === tenant.tenantId || isSwitching;
+            return (
+              <button
+                key={tenant.tenantId}
+                type="button"
+                onClick={() => handleSelect(tenant.tenantId)}
+                className="flex w-full items-center gap-4 rounded-xl border border-slate-200 bg-white p-4 text-left transition hover:border-indigo-400 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                disabled={isPending}
+              >
+                <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-base font-semibold text-indigo-700">
+                  {initials || tenant.code.toUpperCase().slice(0, 2)}
+                </span>
+                <span className="flex-1">
+                  <span className="block text-base font-semibold text-slate-900">
+                    {tenant.name}
+                  </span>
+                  <span className="mt-1 block text-sm text-slate-500">
+                    Role: {tenant.role}
+                  </span>
+                  <span className="mt-1 block text-xs uppercase tracking-wide text-slate-400">
+                    {tenant.code}
+                  </span>
+                </span>
+                <span className="text-sm font-medium text-indigo-600">
+                  {isPending ? 'Switching…' : 'Switch'}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TenantPicker;

--- a/client/src/contexts/TenantContext.tsx
+++ b/client/src/contexts/TenantContext.tsx
@@ -1,0 +1,199 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { fetchJSON, setAccessToken } from '../api/http';
+import type { Role } from '../api/client';
+
+const STORAGE_KEY = 'activeTenantId';
+
+export interface TenantSummary {
+  tenantId: string;
+  name: string;
+  code: string;
+  role: Role;
+}
+
+interface TenantContextValue {
+  tenants: TenantSummary[];
+  activeTenant: TenantSummary | null;
+  role: Role | null;
+  isLoading: boolean;
+  isSwitching: boolean;
+  refreshTenants: () => Promise<void>;
+  setActiveTenant: (tenantId: string) => Promise<void>;
+  withTenantFetch: <T>(fn: (tenant: TenantSummary) => Promise<T>) => Promise<T>;
+}
+
+const TenantContext = createContext<TenantContextValue | undefined>(undefined);
+
+function getStoredTenantId(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(STORAGE_KEY);
+}
+
+function persistTenantId(tenantId: string | null) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (tenantId) {
+    window.localStorage.setItem(STORAGE_KEY, tenantId);
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [tenants, setTenants] = useState<TenantSummary[]>([]);
+  const [activeTenantId, setActiveTenantId] = useState<string | null>(
+    getStoredTenantId(),
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSwitching, setIsSwitching] = useState(false);
+  const [initialised, setInitialised] = useState(false);
+
+  const setActiveTenant = useCallback(async (tenantId: string) => {
+    setIsSwitching(true);
+    try {
+      const response = await fetchJSON('/sessions/switch-tenant', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tenantId }),
+      });
+
+      const nextTenant = response?.tenant as TenantSummary | undefined;
+      const accessToken = response?.accessToken as string | undefined;
+
+      if (!nextTenant || !accessToken) {
+        throw new Error('Invalid switch tenant response');
+      }
+
+      setAccessToken(accessToken);
+      setActiveTenantId(nextTenant.tenantId);
+      persistTenantId(nextTenant.tenantId);
+      setTenants((prev) => {
+        const exists = prev.some((tenant) => tenant.tenantId === nextTenant.tenantId);
+        if (exists) {
+          return prev.map((tenant) =>
+            tenant.tenantId === nextTenant.tenantId ? nextTenant : tenant,
+          );
+        }
+        return [...prev, nextTenant];
+      });
+    } finally {
+      setIsSwitching(false);
+    }
+  }, []);
+
+  const activeTenant = useMemo(
+    () => tenants.find((tenant) => tenant.tenantId === activeTenantId) ?? null,
+    [tenants, activeTenantId],
+  );
+
+  const role = activeTenant?.role ?? null;
+
+  const refreshTenants = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetchJSON('/me/tenants');
+      const list = (response?.tenants ?? []) as TenantSummary[];
+      setTenants(list);
+
+      if (list.length === 1 && !activeTenantId) {
+        try {
+          await setActiveTenant(list[0].tenantId);
+        } catch (error) {
+          console.error('Failed to automatically activate tenant', error);
+        }
+      } else if (
+        activeTenantId &&
+        list.length > 0 &&
+        !list.some((tenant) => tenant.tenantId === activeTenantId)
+      ) {
+        setActiveTenantId(null);
+        persistTenantId(null);
+      }
+    } catch (error) {
+      console.error('Failed to load tenants', error);
+      setTenants([]);
+    } finally {
+      setIsLoading(false);
+      setInitialised(true);
+    }
+  }, [activeTenantId, setActiveTenant]);
+
+  useEffect(() => {
+    void refreshTenants();
+  }, [refreshTenants]);
+
+  useEffect(() => {
+    if (!initialised) {
+      return;
+    }
+    if (!activeTenantId) {
+      const stored = getStoredTenantId();
+      if (stored && stored !== activeTenantId) {
+        void (async () => {
+          try {
+            await setActiveTenant(stored);
+          } catch (error) {
+            console.error('Failed to restore tenant selection', error);
+          }
+        })();
+      }
+    }
+  }, [activeTenantId, initialised, setActiveTenant]);
+
+  const withTenantFetch = useCallback(
+    async <T,>(fn: (tenant: TenantSummary) => Promise<T>) => {
+      if (!activeTenant) {
+        throw new Error('Tenant context is not selected');
+      }
+      return fn(activeTenant);
+    },
+    [activeTenant],
+  );
+
+  const value = useMemo(
+    () => ({
+      tenants,
+      activeTenant,
+      role,
+      isLoading,
+      isSwitching,
+      refreshTenants,
+      setActiveTenant,
+      withTenantFetch,
+    }),
+    [
+      tenants,
+      activeTenant,
+      role,
+      isLoading,
+      isSwitching,
+      refreshTenants,
+      setActiveTenant,
+      withTenantFetch,
+    ],
+  );
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>;
+};
+
+export function useTenant() {
+  const context = useContext(TenantContext);
+  if (!context) {
+    throw new Error('useTenant must be used within a TenantProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a tenant context provider to manage clinic memberships, switching, and persistence
- create a tenant picker modal for selecting clinics when more than one membership exists
- wrap the app in the tenant provider and show overlays for loading, selection, or missing tenants

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68da394a5394832e9dff50db8b03ece2