### PR TITLE
Add tenant-aware header and global search UI

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthProvider';
+import { useSettings } from '../context/SettingsProvider';
+import { useTenant } from '../contexts/TenantContext';
+import LogoutButton from './LogoutButton';
+import TenantPicker from './TenantPicker';
+import GlobalSearch from './GlobalSearch';
+import { AvatarIcon, ChevronDownIcon, MenuIcon } from './icons';
+import { useTranslation } from '../hooks/useTranslation';
+
+interface AppHeaderProps {
+  title: string;
+  subtitle?: string;
+  toolbarContent?: ReactNode;
+  onOpenMobileNav?: () => void;
+  isMobileNavOpen?: boolean;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  Doctor: 'Doctor',
+  AdminAssistant: 'Administrative Assistant',
+  Cashier: 'Cashier',
+  ITAdmin: 'IT Administrator',
+  Pharmacist: 'Pharmacist',
+  PharmacyTech: 'Pharmacy Technician',
+  InventoryManager: 'Inventory Manager',
+  Nurse: 'Nurse',
+  LabTech: 'Laboratory Technician',
+};
+
+const placeholderLogo = (name: string) =>
+  name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('') || '??';
+
+export default function AppHeader({
+  title,
+  subtitle,
+  toolbarContent,
+  onOpenMobileNav,
+  isMobileNavOpen = false,
+}: AppHeaderProps) {
+  const { t } = useTranslation();
+  const { accessToken, user } = useAuth();
+  const { logo } = useSettings();
+  const { activeTenant, tenants, role, isSwitching } = useTenant();
+  const [isTenantPickerOpen, setIsTenantPickerOpen] = useState(false);
+
+  const tenantInitials = useMemo(() => {
+    if (activeTenant) {
+      return placeholderLogo(activeTenant.name);
+    }
+    return '??';
+  }, [activeTenant]);
+
+  const tenantRoleLabel = role ? ROLE_LABELS[role] ?? role : null;
+  const userRoleLabel = user ? ROLE_LABELS[user.role] ?? user.role : t('Team Member');
+  const userEmail = user?.email ?? t('Signed-in user');
+  const searchArea = toolbarContent ?? <GlobalSearch />;
+  const showSettings = user?.role === 'ITAdmin';
+
+  const handleOpenTenantPicker = () => {
+    if (tenants.length <= 1) {
+      return;
+    }
+    setIsTenantPickerOpen(true);
+  };
+
+  return (
+    <>
+      {isTenantPickerOpen && (
+        <TenantPicker forceOpen onClose={() => setIsTenantPickerOpen(false)} />
+      )}
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-3">
+            {onOpenMobileNav && (
+              <button
+                type="button"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-600 hover:bg-gray-100 md:hidden"
+                onClick={onOpenMobileNav}
+                aria-label={t('Open navigation')}
+                aria-expanded={isMobileNavOpen}
+              >
+                <MenuIcon className="h-5 w-5" />
+              </button>
+            )}
+            <div className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm">
+              <span
+                className={`flex h-12 w-12 items-center justify-center rounded-full text-base font-semibold ${
+                  logo ? 'bg-white' : 'bg-blue-100 text-blue-700'
+                }`}
+              >
+                {logo ? (
+                  <img src={logo} alt={t('Clinic logo')} className="h-10 w-10 rounded-full object-cover" />
+                ) : (
+                  tenantInitials
+                )}
+              </span>
+              <div>
+                <div className="text-sm font-semibold text-gray-900">
+                  {activeTenant ? activeTenant.name : t('Select a clinic')}
+                </div>
+                <div className="text-xs uppercase tracking-wide text-gray-500">
+                  {activeTenant ? activeTenant.code : t('No clinic selected')}
+                </div>
+              </div>
+              {tenants.length > 1 && (
+                <button
+                  type="button"
+                  onClick={handleOpenTenantPicker}
+                  className="inline-flex items-center gap-2 rounded-full border border-blue-200 px-3 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50"
+                  disabled={isSwitching}
+                >
+                  {isSwitching ? t('Switching…') : t('Switch clinic')}
+                  <ChevronDownIcon className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+            {tenantRoleLabel && (
+              <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600">
+                {tenantRoleLabel}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end md:gap-4">
+            {searchArea}
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <div className="hidden flex-col text-right text-xs text-gray-500 sm:flex">
+                <span className="font-medium text-gray-700">{userEmail}</span>
+                <span>{userRoleLabel}</span>
+              </div>
+              {showSettings && (
+                <Link to="/settings" className="text-sm font-medium text-blue-600 hover:underline">
+                  {t('Settings')}
+                </Link>
+              )}
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white">
+                <AvatarIcon className="h-6 w-6" />
+              </div>
+              {accessToken && (
+                <LogoutButton className="text-sm font-medium text-red-600 hover:underline" />
+              )}
+            </div>
+          </div>
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+          {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -1,21 +1,11 @@
 import { useState, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import { Link } from 'react-router-dom';
-import {
-  AvatarIcon,
-  CalendarIcon,
-  CloseIcon,
-  DashboardIcon,
-  MenuIcon,
-  PatientsIcon,
-  PharmacyIcon,
-  ReportsIcon,
-  SearchIcon,
-  SettingsIcon,
-} from './icons';
-import LogoutButton from './LogoutButton';
+import { AvatarIcon, CalendarIcon, CloseIcon, DashboardIcon, PatientsIcon, PharmacyIcon, ReportsIcon, SettingsIcon } from './icons';
 import { useAuth } from '../context/AuthProvider';
 import { useSettings } from '../context/SettingsProvider';
 import { useTranslation } from '../hooks/useTranslation';
+import AppHeader from './AppHeader';
+import LogoutButton from './LogoutButton';
 
 type NavigationKey =
   | 'dashboard'
@@ -51,20 +41,6 @@ interface DashboardLayoutProps {
   activeItem?: NavigationKey;
   headerChildren?: ReactNode;
   children: ReactNode;
-}
-
-function DefaultHeaderSearch() {
-  const { t } = useTranslation();
-  return (
-    <div className="relative w-full md:w-72">
-      <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
-      <input
-        type="search"
-        placeholder={t('Search patients...')}
-        className="w-full rounded-full border border-gray-200 bg-gray-50 py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-      />
-    </div>
-  );
 }
 
 export default function DashboardLayout({
@@ -209,52 +185,14 @@ export default function DashboardLayout({
 
       <div className="flex flex-1 flex-col">
         <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
-          <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div className="flex items-center justify-between gap-3 md:justify-start">
-                <Link to="/" className="flex items-center gap-3 text-gray-900">
-                  {logo ? (
-                    <img src={logo} alt={`${displayName} logo`} className="h-10 w-auto rounded" />
-                  ) : (
-                    <span className="text-xl font-semibold">{displayName}</span>
-                  )}
-                  {logo && <span className="text-xl font-semibold">{displayName}</span>}
-                </Link>
-                <button
-                  type="button"
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 text-gray-600 hover:bg-gray-100 md:hidden"
-                  onClick={() => setIsMobileNavOpen(true)}
-                  aria-label={t('Open navigation')}
-                  aria-expanded={isMobileNavOpen}
-                >
-                  <MenuIcon className="h-5 w-5" />
-                </button>
-              </div>
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end md:gap-4">
-                {headerChildren ?? <DefaultHeaderSearch />}
-                <div className="flex flex-wrap items-center justify-end gap-3">
-                  <div className="hidden flex-col text-right text-xs text-gray-500 sm:flex">
-                    <span className="font-medium text-gray-700">{userEmail}</span>
-                    <span>{roleLabel}</span>
-                  </div>
-                  {showSettings && (
-                    <Link to="/settings" className="text-sm font-medium text-blue-600 hover:underline">
-                      {t('Settings')}
-                    </Link>
-                  )}
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white">
-                    <AvatarIcon className="h-6 w-6" />
-                  </div>
-                  {accessToken && (
-                    <LogoutButton className="text-sm font-medium text-red-600 hover:underline" />
-                  )}
-                </div>
-              </div>
-            </div>
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
-              {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
-            </div>
+          <div className="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
+            <AppHeader
+              title={title}
+              subtitle={subtitle}
+              toolbarContent={headerChildren}
+              onOpenMobileNav={() => setIsMobileNavOpen(true)}
+              isMobileNavOpen={isMobileNavOpen}
+            />
           </div>
         </header>
 

--- a/client/src/components/GlobalSearch.tsx
+++ b/client/src/components/GlobalSearch.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  globalSearch,
+  upsertPatientTenant,
+  type GlobalSearchDoctorResult,
+  type GlobalSearchPatientResult,
+  type GlobalSearchResponse,
+} from '../api/client';
+import { useTenant } from '../contexts/TenantContext';
+import { useTranslation } from '../hooks/useTranslation';
+import { PatientsIcon, SearchIcon } from './icons';
+
+interface SearchResultState extends GlobalSearchResponse {
+  query: string;
+}
+
+export default function GlobalSearch() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { activeTenant } = useTenant();
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [results, setResults] = useState<SearchResultState | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [pendingPatientId, setPendingPatientId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(query.trim()), 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    if (!debouncedQuery) {
+      setResults(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    globalSearch(debouncedQuery)
+      .then((data) => {
+        if (cancelled) return;
+        setResults({ ...data, query: debouncedQuery });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError(t('Unable to search at the moment.'));
+        }
+        setResults(null);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery, t]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsDropdownOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, []);
+
+  const hasResults = results && (results.patients.length > 0 || results.doctors.length > 0);
+  const showDropdown = isDropdownOpen && (isLoading || hasResults || !!error);
+
+  const handleFocus = () => {
+    if (debouncedQuery || query) {
+      setIsDropdownOpen(true);
+    }
+  };
+
+  const formatDate = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      }),
+    [],
+  );
+
+  const handleOpenPatient = async (patient: GlobalSearchPatientResult) => {
+    if (!activeTenant) {
+      setError(t('Select a clinic before opening patient records.'));
+      return;
+    }
+
+    setPendingPatientId(patient.patientId);
+    setError(null);
+
+    try {
+      if (!patient.tenants.some((tenant) => tenant.isCurrentTenant)) {
+        const membership = await upsertPatientTenant(patient.patientId);
+        setResults((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            patients: prev.patients.map((item) => {
+              if (item.patientId !== patient.patientId) {
+                return item;
+              }
+              const existing = item.tenants.find((link) => link.tenantId === membership.tenantId);
+              const updatedTenants = existing
+                ? item.tenants.map((link) =>
+                    link.tenantId === membership.tenantId
+                      ? { ...link, mrn: membership.mrn, isCurrentTenant: true, tenantName: activeTenant.name }
+                      : { ...link, isCurrentTenant: false },
+                  )
+                : [
+                    ...item.tenants.map((link) => ({ ...link, isCurrentTenant: false })),
+                    {
+                      tenantId: membership.tenantId,
+                      tenantName: activeTenant.name,
+                      mrn: membership.mrn,
+                      isCurrentTenant: true,
+                    },
+                  ];
+              return {
+                ...item,
+                currentTenantMrn: membership.mrn,
+                tenants: updatedTenants,
+              };
+            }),
+          };
+        });
+      }
+      navigate(`/patients/${patient.patientId}`);
+      setIsDropdownOpen(false);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError(t('Unable to open patient in this clinic.'));
+      }
+    } finally {
+      setPendingPatientId(null);
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative w-full md:w-96">
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setIsDropdownOpen(true);
+          }}
+          onFocus={handleFocus}
+          placeholder={t('Search patients or doctors across clinics...')}
+          className="w-full rounded-full border border-gray-200 bg-white py-2 pl-10 pr-4 text-sm text-gray-700 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+        />
+      </div>
+      {showDropdown && (
+        <div className="absolute left-0 right-0 top-full z-30 mt-2 max-h-96 overflow-y-auto rounded-2xl border border-gray-100 bg-white p-4 shadow-xl">
+          {isLoading && (
+            <div className="flex items-center gap-3 text-sm text-gray-500">
+              <SearchIcon className="h-4 w-4 animate-spin text-blue-500" />
+              {t('Searching...')}
+            </div>
+          )}
+          {!isLoading && error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">{error}</div>
+          )}
+          {!isLoading && !error && results && results.patients.length > 0 && (
+            <div className="space-y-3">
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t('Patients')}</div>
+              {results.patients.map((patient) => {
+                const isPending = pendingPatientId === patient.patientId;
+                return (
+                  <div key={patient.patientId} className="rounded-xl border border-gray-200 p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-semibold text-gray-900">{patient.name}</div>
+                        <div className="text-xs text-gray-500">{t('Global ID')}: {patient.patientId}</div>
+                        <div className="text-xs text-gray-500">
+                          {t('DOB')}: {formatDate.format(new Date(patient.dob))}
+                        </div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          {t('Current clinic MRN')}: {patient.currentTenantMrn ?? t('Not assigned')}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleOpenPatient(patient)}
+                        disabled={isPending}
+                        className="inline-flex items-center justify-center rounded-full bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                      >
+                        {isPending ? t('Opening...') : t('Open in current tenant')}
+                      </button>
+                    </div>
+                    <div className="mt-3 space-y-1 text-xs text-gray-600">
+                      <div className="font-medium text-gray-700">{t('Clinic assignments')}</div>
+                      <div className="flex flex-wrap gap-2">
+                        {patient.tenants.map((tenant) => (
+                          <span
+                            key={`${patient.patientId}-${tenant.tenantId}`}
+                            className={`inline-flex items-center rounded-full px-3 py-1 text-[11px] font-medium ${
+                              tenant.isCurrentTenant
+                                ? 'bg-blue-50 text-blue-700'
+                                : 'bg-gray-100 text-gray-600'
+                            }`}
+                          >
+                            {tenant.tenantName}: {tenant.mrn ?? t('Not assigned')}
+                          </span>
+                        ))}
+                        {patient.tenants.length === 0 && (
+                          <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-medium text-gray-600">
+                            {t('No clinic assignments yet')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {!isLoading && !error && results && results.doctors.length > 0 && (
+            <div className="mt-4 space-y-3">
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t('Doctors')}</div>
+              {results.doctors.map((doctor: GlobalSearchDoctorResult) => (
+                <div key={doctor.doctorId} className="rounded-xl border border-gray-200 p-3">
+                  <div className="text-sm font-semibold text-gray-900">{doctor.name}</div>
+                  <div className="text-xs text-gray-500">{doctor.department}</div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {doctor.tenants.map((tenant) => (
+                      <span
+                        key={`${doctor.doctorId}-${tenant.tenantId}`}
+                        className={`inline-flex items-center rounded-full px-3 py-1 text-[11px] font-medium ${
+                          tenant.isCurrentTenant
+                            ? 'bg-emerald-50 text-emerald-700'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {tenant.tenantName} · {tenant.role}
+                      </span>
+                    ))}
+                    {doctor.tenants.length === 0 && (
+                      <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-medium text-gray-600">
+                        {t('No clinic memberships recorded')}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {!isLoading && !error && results && !hasResults && (
+            <div className="flex flex-col items-center gap-3 py-6 text-center text-sm text-gray-500">
+              <PatientsIcon className="h-8 w-8 text-gray-300" />
+              {t('No results match this search yet.')}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/PatientHeader.tsx
+++ b/client/src/components/PatientHeader.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import {
+  getPatientTenantMeta,
+  upsertPatientTenant,
+  type PatientTenantMeta,
+} from '../api/client';
+import { useTenant } from '../contexts/TenantContext';
+import { useTranslation } from '../hooks/useTranslation';
+
+interface PatientHeaderProps {
+  patientId: string;
+  patientName?: string;
+  className?: string;
+}
+
+export default function PatientHeader({ patientId, patientName, className }: PatientHeaderProps) {
+  const { t } = useTranslation();
+  const { activeTenant } = useTenant();
+
+  const [meta, setMeta] = useState<PatientTenantMeta | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [mrnInput, setMrnInput] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [linkMissing, setLinkMissing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    getPatientTenantMeta(patientId)
+      .then((data) => {
+        if (cancelled) return;
+        setMeta(data);
+        setMrnInput(data.mrn ?? '');
+        setLinkMissing(data.seenAt.length === 0);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : t('Unable to load clinic metadata.');
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [patientId, t]);
+
+  const handleAssignClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setMrnInput(meta?.mrn ?? '');
+  };
+
+  const handleSave = async () => {
+    const trimmed = mrnInput.trim();
+    setIsSaving(true);
+    setError(null);
+    try {
+      const membership = await upsertPatientTenant(patientId, trimmed || undefined);
+      setMeta((prev) => {
+        const current = prev ?? { mrn: null, seenAt: [] };
+        const existingIndex = current.seenAt.findIndex((item) => item.tenantId === membership.tenantId);
+        let seenAt = current.seenAt;
+        if (existingIndex >= 0) {
+          seenAt = current.seenAt.map((item) =>
+            item.tenantId === membership.tenantId
+              ? { ...item, mrn: membership.mrn }
+              : item,
+          );
+        } else if (activeTenant) {
+          seenAt = [
+            ...current.seenAt,
+            { tenantId: membership.tenantId, tenantName: activeTenant.name, mrn: membership.mrn },
+          ];
+        }
+        return {
+          mrn: membership.mrn,
+          seenAt,
+        };
+      });
+      setMrnInput(membership.mrn ?? '');
+      setLinkMissing(false);
+      setIsEditing(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('Unable to assign MRN.');
+      setError(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const currentMrn = meta?.mrn ?? null;
+  const tenantName = activeTenant?.name ?? t('Current clinic');
+
+  return (
+    <section className={`rounded-2xl border border-gray-200 bg-white p-5 shadow-sm ${className ?? ''}`}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="text-sm font-semibold text-gray-900">{patientName ?? t('Patient')}</div>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-600">
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 font-medium text-gray-700">
+              {t('Global ID')}: {patientId}
+            </span>
+            {activeTenant && (
+              <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 font-medium text-blue-700">
+                {t('Viewing as {tenant}', { tenant: activeTenant.name })}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col items-start gap-2 text-sm text-gray-700 md:items-end">
+          {isLoading ? (
+            <span className="text-xs text-gray-500">{t('Loading clinic metadata...')}</span>
+          ) : (
+            <>
+              <span className="text-xs uppercase tracking-wide text-gray-500">{t('MRN in current clinic')}</span>
+              {!isEditing && (
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="text-base font-semibold text-gray-900">
+                    {currentMrn ?? t('Not assigned')}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleAssignClick}
+                    className="inline-flex items-center rounded-full border border-blue-200 px-3 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50"
+                  >
+                    {currentMrn ? t('Edit MRN') : t('Assign MRN')}
+                  </button>
+                </div>
+              )}
+              {isEditing && (
+                <div className="flex flex-wrap items-center gap-2">
+                  <input
+                    type="text"
+                    value={mrnInput}
+                    onChange={(event) => setMrnInput(event.target.value)}
+                    placeholder={t('Enter MRN for {tenant}', { tenant: tenantName })}
+                    className="w-48 rounded-lg border border-gray-300 px-3 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                  >
+                    {isSaving ? t('Saving...') : t('Save')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    className="inline-flex items-center rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100"
+                  >
+                    {t('Cancel')}
+                  </button>
+                </div>
+              )}
+              {linkMissing && !isEditing && (
+                <p className="max-w-xs text-xs text-amber-600">
+                  {t('This patient is not yet associated with the current clinic. Assign an MRN to create the link.')}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+      {error && (
+        <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">{error}</div>
+      )}
+      {!isLoading && meta && meta.seenAt.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">{t('Seen across clinics')}</div>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-600">
+            {meta.seenAt.map((item) => (
+              <span
+                key={`${patientId}-${item.tenantId}`}
+                className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 font-medium text-gray-700"
+              >
+                {item.tenantName}: {item.mrn ?? t('MRN pending')}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/TenantPicker.tsx
+++ b/client/src/components/TenantPicker.tsx
@@ -9,12 +9,17 @@ const placeholderLogo = (name: string) =>
     .map((part) => part[0]?.toUpperCase())
     .join('');
 
-const TenantPicker: React.FC = () => {
+interface TenantPickerProps {
+  forceOpen?: boolean;
+  onClose?: () => void;
+}
+
+const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose }) => {
   const { tenants, activeTenant, setActiveTenant, isSwitching } = useTenant();
   const [error, setError] = useState<string | null>(null);
   const [pendingTenantId, setPendingTenantId] = useState<string | null>(null);
 
-  const shouldShow = tenants.length > 1 && !activeTenant;
+  const shouldShow = forceOpen || (tenants.length > 1 && !activeTenant);
 
   if (!shouldShow) {
     return null;
@@ -25,6 +30,7 @@ const TenantPicker: React.FC = () => {
     setPendingTenantId(tenantId);
     try {
       await setActiveTenant(tenantId);
+      onClose?.();
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);
@@ -37,7 +43,16 @@ const TenantPicker: React.FC = () => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-6 py-12">
-      <div className="w-full max-w-3xl rounded-2xl bg-white p-10 shadow-2xl">
+      <div className="relative w-full max-w-3xl rounded-2xl bg-white p-10 shadow-2xl">
+        {forceOpen && onClose && (
+          <button
+            type="button"
+            className="absolute right-4 top-4 rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-500 hover:bg-slate-100"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        )}
         <div className="mb-8 text-center">
           <h2 className="text-2xl font-semibold text-slate-900">Choose your clinic</h2>
           <p className="mt-2 text-sm text-slate-500">

--- a/client/src/components/WrongTenantBanner.tsx
+++ b/client/src/components/WrongTenantBanner.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { useTenant } from '../contexts/TenantContext';
+import { useTranslation } from '../hooks/useTranslation';
+
+interface WrongTenantBannerProps {
+  recordTenantId: string | null | undefined;
+  recordTenantName?: string | null;
+  className?: string;
+  onSwitched?: (tenantId: string) => void;
+}
+
+export default function WrongTenantBanner({
+  recordTenantId,
+  recordTenantName,
+  className,
+  onSwitched,
+}: WrongTenantBannerProps) {
+  const { t } = useTranslation();
+  const { activeTenant, tenants, setActiveTenant, isSwitching } = useTenant();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  if (!recordTenantId || !activeTenant || recordTenantId === activeTenant.tenantId) {
+    return null;
+  }
+
+  const knownTenant = tenants.find((tenant) => tenant.tenantId === recordTenantId);
+  const targetName = recordTenantName ?? knownTenant?.name ?? t('another clinic');
+  const activeName = activeTenant.name;
+
+  const handleSwitch = async () => {
+    if (!recordTenantId) return;
+    setError(null);
+    setPending(true);
+    try {
+      await setActiveTenant(recordTenantId);
+      onSwitched?.(recordTenantId);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError(t('Unable to switch clinics right now.'));
+      }
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const containerClassName = [
+    'rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={containerClassName} role="alert">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="font-semibold">{t('Clinic mismatch')}</div>
+          <p className="mt-1 text-xs text-amber-800">
+            {t('This record belongs to {target}. You are currently working in {active}.', {
+              target: targetName,
+              active: activeName,
+            })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleSwitch}
+          disabled={pending || isSwitching}
+          className="inline-flex items-center justify-center rounded-full bg-amber-600 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-amber-700 disabled:cursor-not-allowed disabled:bg-amber-400"
+        >
+          {pending || isSwitching
+            ? t('Switching...')
+            : t('Switch to {tenant}', { tenant: knownTenant?.name ?? t('that clinic') })}
+        </button>
+      </div>
+      {error && (
+        <div className="mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">{error}</div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/icons.tsx
+++ b/client/src/components/icons.tsx
@@ -176,3 +176,11 @@ export function CloseIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function ChevronDownIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 7.5l5 5 5-5" />
+    </svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce a tenant-aware AppHeader with global search integration and update the dashboard layout to use it
- add global patient/doctor search, patient tenant metadata header, and wrong-tenant banner components
- enhance API utilities for global search and MRN linking while improving HTTP error handling and tenant switching UX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da3f21c17c832eb42d2df8f3d2b05f