### PR TITLE
Add CLI helper for provisioning clinics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Thu Kha (သုခ) EMR is a reference implementation of an electronic medical r
    ```
    The API is available at `http://localhost:8080` and the Vite-powered web client at `http://localhost:5173`.
 
+### Creating additional clinics
+
+Initial seed data provisions a single clinic and automatically links all active IT Administrators and Administrative Assistants to it. If you need to register another clinic later on, run the CLI helper and pass the clinic name (plus any admin email addresses that should receive access immediately):
+
+```bash
+npm run tenant:create -- --name "Downtown Clinic" --code downtown --admin admin@example.com
+```
+
+You can repeat `--admin` to associate multiple staff members. The command creates the clinic, ensures the slug/code is unique, and then grants the listed users access with their existing roles. IT Administrators without a clinic membership will see a "No clinics available" banner until they are assigned to at least one clinic.
+
 ## Neon PostgreSQL Setup
 Provision a PostgreSQL instance on [Neon](https://neon.tech) and set the `DATABASE_URL` and `DIRECT_URL` in `.env` (include `sslmode=require` for both). Enable the required extensions:
 ```sql

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prisma:migrate": "prisma migrate dev --name pharmacy_mvp",
     "prisma:seed": "tsx prisma/seed.mts",
     "seed": "prisma db seed",
+    "tenant:create": "tsx scripts/createTenant.ts",
     "reset:db": "prisma migrate reset --force",
     "studio": "prisma studio"
   },

--- a/scripts/createTenant.ts
+++ b/scripts/createTenant.ts
@@ -1,0 +1,120 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+interface CliArgs {
+  name?: string;
+  code?: string;
+  admin?: string[];
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { admin: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+    if (!current.startsWith('--')) continue;
+    const key = current.slice(2);
+    const next = argv[i + 1];
+    switch (key) {
+      case 'name':
+        if (next && !next.startsWith('--')) {
+          args.name = next;
+          i += 1;
+        }
+        break;
+      case 'code':
+        if (next && !next.startsWith('--')) {
+          args.code = next;
+          i += 1;
+        }
+        break;
+      case 'admin': {
+        if (!args.admin) args.admin = [];
+        if (next && !next.startsWith('--')) {
+          args.admin.push(next.toLowerCase());
+          i += 1;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return args;
+}
+
+function slugifyName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32);
+}
+
+async function ensureAdmins(emails: string[], tenantId: string) {
+  if (emails.length === 0) {
+    console.log('⚠️  No --admin email provided. Create the tenant membership manually if required.');
+    return;
+  }
+
+  for (const email of emails) {
+    const user = await prisma.user.findFirst({
+      where: {
+        email: { equals: email, mode: 'insensitive' },
+        status: 'active',
+      },
+      select: { userId: true, role: true, email: true },
+    });
+
+    if (!user) {
+      console.warn(`⚠️  Skipping ${email}: no active user found.`);
+      continue;
+    }
+
+    await prisma.userTenant.upsert({
+      where: { tenantId_userId: { tenantId, userId: user.userId } },
+      update: { role: user.role },
+      create: { tenantId, userId: user.userId, role: user.role },
+    });
+
+    console.log(`✅ Added ${user.email} (${user.role}) to the clinic.`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const name = args.name?.trim();
+
+  if (!name) {
+    console.error('Usage: npm run tenant:create -- --name "Clinic Name" [--code slug] [--admin admin@example.com]');
+    process.exit(1);
+  }
+
+  const code = args.code?.trim() || slugifyName(name);
+
+  try {
+    const tenant = await prisma.tenant.create({
+      data: {
+        name,
+        code,
+      },
+    });
+
+    console.log(`🏥 Created clinic "${tenant.name}" (code: ${tenant.code ?? 'n/a'})`);
+
+    const adminEmails = args.admin ?? [];
+    await ensureAdmins(adminEmails, tenant.tenantId);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`❌ Failed to create clinic: ${error.message}`);
+    } else {
+      console.error('❌ Failed to create clinic due to an unknown error.');
+    }
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a tenant:create CLI script to register new clinics and assign administrators automatically
- document the workflow for creating additional clinics and expose an npm script entry point

## Testing
- npm run lint *(fails: repository lacks the ESLint flat config expected by eslint@9)*

------
https://chatgpt.com/codex/tasks/task_e_68da56f21574832ea4a9113f9baca101