### PR TITLE
feat: add system admin role and clinic configuration

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -85,7 +85,7 @@ function AppContent() {
         <Route
           path="/patients/:patientId/problems"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin']}>
               <ProblemList />
             </RouteGuard>
           }
@@ -93,7 +93,7 @@ function AppContent() {
         <Route
           path="/appointments"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin']}>
               <AppointmentsPage />
             </RouteGuard>
           }
@@ -109,7 +109,7 @@ function AppContent() {
         <Route
           path="/appointments/:id"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant']}>
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin']}>
               <AppointmentDetail />
             </RouteGuard>
           }
@@ -133,7 +133,7 @@ function AppContent() {
         <Route
           path="/register"
           element={
-            <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin', 'SystemAdmin']}>
               <RegisterPatient />
             </RouteGuard>
           }
@@ -165,7 +165,7 @@ function AppContent() {
         <Route
           path="/lab-orders"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin']}>
               <LabOrdersPage />
             </RouteGuard>
           }
@@ -173,7 +173,7 @@ function AppContent() {
         <Route
           path="/lab-orders/:labOrderId"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin']}>
               <LabOrderDetailPage />
             </RouteGuard>
           }
@@ -181,7 +181,7 @@ function AppContent() {
         <Route
           path="/pharmacy/queue"
           element={
-            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin']}>
               <PharmacyQueue />
             </RouteGuard>
           }
@@ -189,7 +189,7 @@ function AppContent() {
         <Route
           path="/pharmacy/inventory"
           element={
-            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin']}>
               <PharmacyInventory />
             </RouteGuard>
           }
@@ -197,7 +197,7 @@ function AppContent() {
         <Route
           path="/pharmacy/drugs/new"
           element={
-            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin']}>
               <AddDrug />
             </RouteGuard>
           }
@@ -205,7 +205,7 @@ function AppContent() {
         <Route
           path="/billing/workspace"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist']}>
               <BillingWorkspace />
             </RouteGuard>
           }
@@ -213,7 +213,7 @@ function AppContent() {
         <Route
           path="/billing/visit/:visitId"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist']}>
               <VisitBilling />
             </RouteGuard>
           }
@@ -221,7 +221,7 @@ function AppContent() {
         <Route
           path="/billing/pos"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin']}>
               <PosList />
             </RouteGuard>
           }
@@ -237,7 +237,7 @@ function AppContent() {
         <Route
           path="/settings"
           element={
-            <RouteGuard allowedRoles={['ITAdmin']}>
+            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin']}>
               <Settings />
             </RouteGuard>
           }
@@ -245,7 +245,7 @@ function AppContent() {
         <Route
           path="/settings/services"
           element={
-            <RouteGuard allowedRoles={['ITAdmin']}>
+            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin']}>
               <SettingsServices />
             </RouteGuard>
           }

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -5,11 +5,39 @@ export type Role =
   | 'AdminAssistant'
   | 'Cashier'
   | 'ITAdmin'
+  | 'SystemAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
   | 'InventoryManager'
   | 'Nurse'
   | 'LabTech';
+
+export interface ClinicConfiguration {
+  appName: string;
+  logo: string | null;
+  widgetEnabled: boolean;
+  updatedAt: string;
+}
+
+export interface UpdateClinicConfigurationPayload {
+  appName?: string;
+  logo?: string | null;
+  widgetEnabled?: boolean;
+}
+
+export function getClinicConfiguration(): Promise<ClinicConfiguration> {
+  return fetchJSON('/settings/clinic');
+}
+
+export function updateClinicConfiguration(
+  payload: UpdateClinicConfigurationPayload,
+): Promise<ClinicConfiguration> {
+  return fetchJSON('/settings/clinic', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
 
 export interface Patient {
   patientId: string;

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -22,6 +22,7 @@ const ROLE_LABELS: Record<string, string> = {
   AdminAssistant: 'Administrative Assistant',
   Cashier: 'Cashier',
   ITAdmin: 'IT Administrator',
+  SystemAdmin: 'System Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',
@@ -61,7 +62,7 @@ export default function AppHeader({
   const userRoleLabel = user ? ROLE_LABELS[user.role] ?? user.role : t('Team Member');
   const userEmail = user?.email ?? t('Signed-in user');
   const searchArea = toolbarContent ?? <GlobalSearch />;
-  const showSettings = user?.role === 'ITAdmin';
+  const showSettings = user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
 
   const handleOpenTenantPicker = () => {
     if (tenants.length <= 1) {

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -56,23 +56,23 @@ export default function DashboardLayout({
   const roleLabel = user ? t(ROLE_LABELS[user.role] ?? 'Team Member') : t('Team Member');
   const navItems = navigation.filter((item) => {
     if (item.key === 'settings') {
-      return user?.role === 'ITAdmin';
+      return user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
     }
     if (item.key === 'billing') {
-      return user && ['Cashier', 'ITAdmin', 'Doctor', 'Pharmacist'].includes(user.role);
+      return user && ['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist'].includes(user.role);
     }
     if (item.key === 'pharmacy') {
       return (
-        user && ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin'].includes(user.role)
+        user && ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin'].includes(user.role)
       );
     }
     if (item.key === 'lab') {
-      return user && ['Doctor', 'LabTech', 'ITAdmin'].includes(user.role);
+      return user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role);
     }
     return true;
   });
   const displayName = appName || t('EMR System');
-  const showSettings = user?.role === 'ITAdmin';
+  const showSettings = user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const userEmail = user?.email ?? t('Signed-in user');
 
@@ -211,6 +211,7 @@ const ROLE_LABELS: Record<string, string> = {
   AdminAssistant: 'Administrative Assistant',
   Cashier: 'Cashier',
   ITAdmin: 'IT Administrator',
+  SystemAdmin: 'System Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',

--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -19,7 +19,12 @@ export default function RouteGuard({ children, allowedRoles }: Props) {
   if (!user) {
     return null;
   }
-  if (allowedRoles && !allowedRoles.includes(user.role) && user.role !== 'ITAdmin') {
+  if (
+    allowedRoles &&
+    !allowedRoles.includes(user.role) &&
+    user.role !== 'ITAdmin' &&
+    user.role !== 'SystemAdmin'
+  ) {
     return <Navigate to="/" replace />;
   }
   return (

--- a/client/src/components/VitalsCard.tsx
+++ b/client/src/components/VitalsCard.tsx
@@ -30,7 +30,7 @@ export default function VitalsCard({ patientId, defaultVisitId = '', limit = 10 
   const { t } = useTranslation();
   const { user } = useAuth();
   const canRecord = useMemo(
-    () => user && ['Nurse', 'Doctor', 'ITAdmin'].includes(user.role),
+    () => user && ['Nurse', 'Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
     [user],
   );
   const [vitalsList, setVitalsList] = useState<VitalsEntry[]>([]);

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -11,6 +11,7 @@ Signed-in user,Signed-in user,ဝင်ရောက်ထားသောအသ�
 Doctor,Doctor,ဆရာဝန်
 Administrative Assistant,Administrative Assistant,စီမံရေးကူညီသူ
 IT Administrator,IT Administrator,IT အုပ်ချုပ်ရေးမှူး
+System Administrator,System Administrator,စနစ် အုပ်ချုပ်ရေးမှူး
 Sign in to your account,Sign in to your account,သင့်အကောင့်သို့ ဝင်ရောက်ပါ
 Username or Email,Username or Email,အသုံးပြုသူအမည် သို့မဟုတ် အီးမေးလ်
 Password,Password,စကားဝှက်
@@ -122,6 +123,7 @@ Jump into commonly referenced patient segments.,Jump into commonly referenced pa
 Need to add someone?,Need to add someone?,တစ်ယောက် ထပ်ထည့်လိုပါသလား။
 Can't find the patient you're looking for? Create a new record in just a few steps.,Can't find the patient you're looking for? Create a new record in just a few steps.,ရှာဖွေနေသော လူနာကို မတွေ့ဘူးလား။ အဆင့်အနည်းငယ်သာဖြင့် မှတ်တမ်းအသစ်တစ်ခု ဖန်တီးနိုင်ပါသည်။
 IT Administrator Dashboard,IT Administrator Dashboard,IT အုပ်ချုပ်ရေးမှူး ဒက်ရှ်ဘုတ်
+System Administrator Dashboard,System Administrator Dashboard,စနစ် အုပ်ချုပ်ရေးမှူး ဒက်ရှ်ဘုတ်
 Monitor user accounts, system access, and staff setup.,Monitor user accounts, system access, and staff setup.,အသုံးပြုသူအကောင့်များ၊ စနစ်ဝင်ရောက်ခွင့်နှင့် ဝန်ထမ်း စနစ်သတ်မှတ်ခြင်းကို စောင့်ကြည့်ပါ။
 Staff Accounts,Staff Accounts,ဝန်ထမ်းအကောင့်များ
 Active Accounts,Active Accounts,လှုပ်ရှားနေသော အကောင့်များ
@@ -229,6 +231,10 @@ Expiry date,Expiry date,သက်တမ်းကုန်နေ့
 Unit cost,Unit cost,ယူနစ်စျေးနှုန်း
 Stock recorded successfully.,Stock recorded successfully.,စတော့မှတ်တမ်းတင်ပြီးပါပြီ။
 Saving…,Saving…,သိမ်းဆည်းနေပါသည်...
+Save Changes,Save Changes,ပြင်ဆင်ချက်များကို သိမ်းဆည်းပါ
+Only system administrators can update branding details.,Only system administrators can update branding details.,စနစ် အုပ်ချုပ်ရေးမှူးများသာ တံဆိပ် အချက်အလက်များကို ပြင်ဆင်ခွင့်ရှိသည်။
+Branding updated.,Branding updated.,တံဆိပ် အချက်အလက်များကို ပြင်ဆင်ပြီးပါပြီ။
+Unable to update branding.,Unable to update branding.,တံဆိပ် အချက်အလက်များကို ပြင်ဆင်၍မရနိုင်ပါ။
 Record stock,Record stock,စတော့ကို မှတ်တမ်းတင်ပါ
 Adjust Inventory,Adjust Inventory,စတော့ ပြင်ဆင်ပါ
 Update quantities for existing batches after cycle counts or corrections.,Update quantities for existing batches after cycle counts or corrections.,စတော့ရေတွက်ပြီးနောက် လက်ရှိဘုတ်များ၏ အရေအတွက်ကို ပြင်ဆင်ပါ။

--- a/client/src/pages/AppointmentsPage.tsx
+++ b/client/src/pages/AppointmentsPage.tsx
@@ -198,9 +198,10 @@ function formatTimeRange(startMin: number, endMin: number) {
 export default function AppointmentsPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const userRole = user?.role ?? 'ITAdmin';
+  const userRole = user?.role ?? 'SystemAdmin';
   const isDoctorUser = userRole === 'Doctor';
-  const canCreateAppointment = userRole === 'AdminAssistant' || userRole === 'ITAdmin';
+  const canCreateAppointment =
+    userRole === 'AdminAssistant' || userRole === 'ITAdmin' || userRole === 'SystemAdmin';
   const { t } = useTranslation();
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [loading, setLoading] = useState(false);

--- a/client/src/pages/BillingWorkspace.tsx
+++ b/client/src/pages/BillingWorkspace.tsx
@@ -110,10 +110,16 @@ export default function BillingWorkspace() {
   const [patientVisitsLoading, setPatientVisitsLoading] = useState(false);
   const [patientVisitsError, setPatientVisitsError] = useState<string | null>(null);
   const [patientVisits, setPatientVisits] = useState<Visit[]>([]);
-  const canCollectPayments = user ? ['Cashier', 'ITAdmin'].includes(user.role) : false;
+  const canCollectPayments = user
+    ? ['Cashier', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    : false;
   const canTriggerVoid = canCollectPayments;
-  const canCreateInvoices = user ? ['Cashier', 'ITAdmin', 'Doctor'].includes(user.role) : false;
-  const canRepostPharmacy = user ? ['Pharmacist', 'ITAdmin'].includes(user.role) : false;
+  const canCreateInvoices = user
+    ? ['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor'].includes(user.role)
+    : false;
+  const canRepostPharmacy = user
+    ? ['Pharmacist', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    : false;
 
   useEffect(() => {
     const handle = window.setTimeout(() => setDebouncedPatientQuery(patientQuery.trim()), 300);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -55,8 +55,8 @@ export default function Home() {
     return <DoctorQueueDashboard />;
   }
 
-  if (user?.role === 'ITAdmin') {
-    return <ITAdminDashboard />;
+  if (user?.role === 'ITAdmin' || user?.role === 'SystemAdmin') {
+    return <ITAdminDashboard role={user.role} />;
   }
 
   if (user?.role === 'Pharmacist' || user?.role === 'PharmacyTech') {
@@ -70,7 +70,7 @@ export default function Home() {
   return <TeamDashboard role={user?.role} />;
 }
 
-function ITAdminDashboard() {
+function ITAdminDashboard({ role = 'ITAdmin' }: { role?: 'ITAdmin' | 'SystemAdmin' }) {
   const { accessToken } = useAuth();
   const { t } = useTranslation();
   const [usersData, setUsersData] = useState<UserAccount[] | null>(null);
@@ -208,7 +208,7 @@ function ITAdminDashboard() {
 
   return (
     <DashboardLayout
-      title={t('IT Administrator Dashboard')}
+      title={t(role === 'SystemAdmin' ? 'System Administrator Dashboard' : 'IT Administrator Dashboard')}
       subtitle={t('Monitor user accounts, system access, and staff setup.')}
       activeItem="dashboard"
     >
@@ -340,6 +340,7 @@ const ACCOUNT_ROLE_LABELS: Record<UserAccount['role'], string> = {
   Cashier: 'Cashier',
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
+  SystemAdmin: 'System Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',

--- a/client/src/pages/LabOrderDetail.tsx
+++ b/client/src/pages/LabOrderDetail.tsx
@@ -28,7 +28,10 @@ export default function LabOrderDetailPage() {
   const { labOrderId } = useParams<'labOrderId'>();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canEnterResults = useMemo(() => user && ['LabTech', 'ITAdmin'].includes(user.role), [user]);
+  const canEnterResults = useMemo(
+    () => user && ['LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    [user],
+  );
   const [order, setOrder] = useState<LabOrderEntry | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/client/src/pages/LabOrders.tsx
+++ b/client/src/pages/LabOrders.tsx
@@ -25,9 +25,12 @@ export default function LabOrdersPage() {
   const { t } = useTranslation();
   const { user } = useAuth();
   const navigate = useNavigate();
-  const canOrder = useMemo(() => user && ['Doctor', 'ITAdmin'].includes(user.role), [user]);
+  const canOrder = useMemo(
+    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    [user],
+  );
   const canView = useMemo(
-    () => user && ['Doctor', 'LabTech', 'ITAdmin'].includes(user.role),
+    () => user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role),
     [user],
   );
   const [orders, setOrders] = useState<LabOrderEntry[]>([]);

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -168,7 +168,7 @@ export default function PatientDetail() {
     );
   }
 
-  const canViewProblems = user && ['Doctor', 'Nurse', 'ITAdmin'].includes(user.role);
+  const canViewProblems = user && ['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin'].includes(user.role);
 
   const headerActions = (
     <div className="flex flex-col gap-2 md:flex-row md:items-center">

--- a/client/src/pages/PharmacyQueue.tsx
+++ b/client/src/pages/PharmacyQueue.tsx
@@ -19,7 +19,9 @@ export default function PharmacyQueue() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const canDispense = user ? ['Pharmacist', 'PharmacyTech'].includes(user.role) : false;
-  const canManageInventory = user ? ['InventoryManager', 'ITAdmin'].includes(user.role) : false;
+  const canManageInventory = user
+    ? ['InventoryManager', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    : false;
 
   const statusLabels = useMemo(
     () => ({

--- a/client/src/pages/ProblemList.tsx
+++ b/client/src/pages/ProblemList.tsx
@@ -23,7 +23,10 @@ export default function ProblemList() {
   const { patientId } = useParams<'patientId'>();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const canEdit = useMemo(() => user && ['Doctor', 'ITAdmin'].includes(user.role), [user]);
+  const canEdit = useMemo(
+    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    [user],
+  );
   const canResolve = canEdit;
   const [problems, setProblems] = useState<ProblemEntry[]>([]);
   const [statusFilter, setStatusFilter] = useState<'ACTIVE' | 'RESOLVED' | 'ALL'>('ACTIVE');

--- a/prisma/migrations/20250501000000_system_admin_role/migration.sql
+++ b/prisma/migrations/20250501000000_system_admin_role/migration.sql
@@ -1,0 +1,22 @@
+-- AlterEnum
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'SystemAdmin';
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "TenantConfiguration" (
+  "tenantId" UUID NOT NULL,
+  "appName" TEXT NOT NULL DEFAULT 'EMR System',
+  "logo" TEXT,
+  "widgetEnabled" BOOLEAN NOT NULL DEFAULT FALSE,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TenantConfiguration_pkey" PRIMARY KEY ("tenantId"),
+  CONSTRAINT "TenantConfiguration_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("tenantId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Seed existing tenants with configuration entries
+INSERT INTO "TenantConfiguration" ("tenantId", "appName", "widgetEnabled")
+SELECT "tenantId", "name", FALSE
+FROM "Tenant"
+WHERE NOT EXISTS (
+  SELECT 1 FROM "TenantConfiguration" tc WHERE tc."tenantId" = "Tenant"."tenantId"
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,11 +26,23 @@ enum Role {
   AdminAssistant
   Cashier
   ITAdmin
+  SystemAdmin
   Pharmacist
   PharmacyTech
   InventoryManager
   Nurse
   LabTech
+}
+
+model TenantConfiguration {
+  tenantId      String   @id @db.Uuid
+  appName       String   @default("EMR System")
+  logo          String?
+  widgetEnabled Boolean  @default(false)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [tenantId], onDelete: Cascade)
 }
 
 model Tenant {
@@ -56,6 +68,7 @@ model Tenant {
   invoiceItems       InvoiceItem[]
   payments           Payment[]
   paymentAllocations PaymentAllocation[]
+  configuration      TenantConfiguration?
 }
 
 enum AppointmentStatus {

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -14,10 +14,12 @@ function d(s) { return s ? new Date(`${s}T00:00:00Z`) : null; }
 async function seedUsers() {
   const adminEmail = 'admin@example.com';
   const assistantEmail = 'assistant@example.com';
+  const systemAdminEmail = 'sysadmin@example.com';
   const doctorEmail = 'drsmith@example.com';
 
   const adminHash = await bcrypt.hash('AdminPass123!', 10);
   const assistantHash = await bcrypt.hash('AssistantPass123!', 10);
+  const systemAdminHash = await bcrypt.hash('SysAdminPass123!', 10);
   const doctorHash = await bcrypt.hash('DoctorPass123!', 10);
 
   const doctorRecord = await prisma.doctor.findFirst({
@@ -50,6 +52,20 @@ async function seedUsers() {
     await prisma.user.update({ where: { email: assistantEmail }, data: assistantData });
   } else {
     await prisma.user.create({ data: assistantData });
+  }
+
+  const systemAdmin = await prisma.user.findUnique({ where: { email: systemAdminEmail } });
+  const systemAdminData = {
+    email: systemAdminEmail,
+    passwordHash: systemAdminHash,
+    role: 'SystemAdmin',
+    status: 'active',
+    doctorId: null,
+  };
+  if (systemAdmin) {
+    await prisma.user.update({ where: { email: systemAdminEmail }, data: systemAdminData });
+  } else {
+    await prisma.user.create({ data: systemAdminData });
   }
 
   const doctor = await prisma.user.findUnique({ where: { email: doctorEmail } });

--- a/src/middleware/requireTenantRoles.ts
+++ b/src/middleware/requireTenantRoles.ts
@@ -17,7 +17,10 @@ export function requireTenantRoles(...roles: Role[]) {
         return res.status(400).json({ error: 'Tenant context missing' });
       }
 
-      if (user.role === 'ITAdmin' && (roles.length === 0 || roles.includes('ITAdmin'))) {
+      if (
+        (user.role === 'ITAdmin' || user.role === 'SystemAdmin') &&
+        (roles.length === 0 || roles.includes('ITAdmin') || roles.includes('SystemAdmin'))
+      ) {
         req.tenantRole = user.role as RoleName;
         return next();
       }

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -9,6 +9,7 @@ export type RoleName =
   | 'AdminAssistant'
   | 'Cashier'
   | 'ITAdmin'
+  | 'SystemAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
   | 'InventoryManager'
@@ -93,7 +94,7 @@ export function requireRole(...roles: RoleName[]) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    if (user.role === 'ITAdmin') {
+    if (user.role === 'ITAdmin' || user.role === 'SystemAdmin') {
       return next();
     }
 

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -1,0 +1,133 @@
+import { Router, type Response } from 'express';
+import type { AuthRequest } from '../auth/index.js';
+import { PrismaClient } from '@prisma/client';
+import { z } from 'zod';
+import { requireRole } from '../auth/index.js';
+import { requireTenantRoles } from '../../middleware/requireTenantRoles.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+const updateSchema = z
+  .object({
+    appName: z
+      .string()
+      .trim()
+      .min(1, 'Application name is required')
+      .max(120, 'Application name is too long')
+      .optional(),
+    logo: z.union([z.string(), z.null()]).optional(),
+    widgetEnabled: z.boolean().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.logo !== undefined && value.logo !== null && value.logo.length > 1_000_000) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['logo'],
+        message: 'Logo payload is too large',
+      });
+    }
+  });
+
+type UpdateInput = z.infer<typeof updateSchema>;
+
+function mapConfiguration(configuration: {
+  appName: string;
+  logo: string | null;
+  widgetEnabled: boolean;
+  updatedAt: Date;
+}) {
+  return {
+    appName: configuration.appName,
+    logo: configuration.logo,
+    widgetEnabled: configuration.widgetEnabled,
+    updatedAt: configuration.updatedAt.toISOString(),
+  };
+}
+
+async function ensureConfiguration(tenantId: string) {
+  const existing = await prisma.tenantConfiguration.findUnique({ where: { tenantId } });
+  if (existing) {
+    return existing;
+  }
+
+  const tenant = await prisma.tenant.findUnique({
+    where: { tenantId },
+    select: { name: true },
+  });
+
+  return prisma.tenantConfiguration.create({
+    data: {
+      tenantId,
+      appName: tenant?.name ?? 'EMR System',
+      widgetEnabled: false,
+      logo: null,
+    },
+  });
+}
+
+router.get('/clinic', requireTenantRoles(), async (req: AuthRequest, res: Response) => {
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    return res.status(400).json({ error: 'Tenant context missing' });
+  }
+
+  const configuration = await ensureConfiguration(tenantId);
+  return res.json(mapConfiguration(configuration));
+});
+
+router.patch(
+  '/clinic',
+  requireRole('SystemAdmin'),
+  requireTenantRoles(),
+  async (req: AuthRequest, res: Response) => {
+    if (req.user?.role !== 'SystemAdmin') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const tenantId = req.tenantId;
+    if (!tenantId) {
+      return res.status(400).json({ error: 'Tenant context missing' });
+    }
+
+    const parsed = updateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const updates: UpdateInput = parsed.data;
+
+    if (Object.keys(updates).length === 0) {
+      const configuration = await ensureConfiguration(tenantId);
+      return res.json(mapConfiguration(configuration));
+    }
+
+    const configuration = await ensureConfiguration(tenantId);
+    const data: {
+      appName?: string;
+      logo?: string | null;
+      widgetEnabled?: boolean;
+    } = {};
+
+    if (updates.appName !== undefined) {
+      data.appName = updates.appName.trim() || 'EMR System';
+    }
+
+    if (updates.logo !== undefined) {
+      data.logo = updates.logo;
+    }
+
+    if (updates.widgetEnabled !== undefined) {
+      data.widgetEnabled = updates.widgetEnabled;
+    }
+
+    const updated = await prisma.tenantConfiguration.update({
+      where: { tenantId: configuration.tenantId },
+      data,
+    });
+
+    return res.json(mapConfiguration(updated));
+  }
+);
+
+export default router;

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -13,6 +13,7 @@ const roleSchema = z.enum([
   'AdminAssistant',
   'Cashier',
   'ITAdmin',
+  'SystemAdmin',
   'Pharmacist',
   'PharmacyTech',
   'InventoryManager',

--- a/src/routes/appointments.ts
+++ b/src/routes/appointments.ts
@@ -337,7 +337,12 @@ router.patch(
       }
 
       const targetStatus = body.status;
-      if ((targetStatus === 'InProgress' || targetStatus === 'Completed') && user.role !== 'Doctor' && user.role !== 'ITAdmin') {
+      if (
+        (targetStatus === 'InProgress' || targetStatus === 'Completed') &&
+        user.role !== 'Doctor' &&
+        user.role !== 'ITAdmin' &&
+        user.role !== 'SystemAdmin'
+      ) {
         throw new ForbiddenError('Only doctors can start or complete visits');
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import sessionsRouter from './routes/sessions.js';
 import meRouter from './routes/me.js';
 import patientTenantsRouter from './routes/patientTenants.js';
 import searchRouter from './routes/search.js';
+import settingsRouter from './modules/settings/index.js';
 
 export const apiRouter = Router();
 
@@ -45,6 +46,7 @@ apiRouter.use('/sessions', sessionsRouter);
 apiRouter.use('/me', meRouter);
 apiRouter.use(patientTenantsRouter);
 apiRouter.use('/search', searchRouter);
+apiRouter.use('/settings', settingsRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;


### PR DESCRIPTION
## Summary
- introduce a SystemAdmin role on the API and UI, updating access control, seeds, and navigation labels
- add tenant clinic configuration persistence with new settings endpoints and a restricted system admin UI for branding and widget controls
- expand translations, migrations, and client context to load and update shared clinic branding data

## Testing
- npm test *(fails: Prisma requires DATABASE_URL in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5ae539d8832e826f9130ccf3a398