### PR TITLE
Ensure system admin role seeding fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "zod": "^3"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
         "@types/cors": "^2",
         "@types/express": "^4",
         "@types/jest": "^29",
@@ -1987,6 +1988,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "seed": "tsx prisma/seed.mts"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/cors": "^2",
     "@types/express": "^4",
     "@types/jest": "^29",


### PR DESCRIPTION
## Summary
- ensure the Prisma seed checks for the SystemAdmin enum value and adds it when missing
- upsert the system admin user and tenant membership during seeding with configurable credentials
- add @types/bcrypt to support the new seeding logic

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68db437045e4832e868ad5c0b7eab65c