### PR TITLE
Add system admin clinic management UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import SettingsServices from './pages/SettingsServices';
 import ProblemList from './pages/ProblemList';
 import LabOrdersPage from './pages/LabOrders';
 import LabOrderDetailPage from './pages/LabOrderDetail';
+import ClinicManagement from './pages/ClinicManagement';
 import './styles/App.css';
 import { TenantProvider, useTenant } from './contexts/TenantContext';
 import TenantPicker from './components/TenantPicker';
@@ -239,6 +240,14 @@ function AppContent() {
           element={
             <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin']}>
               <Settings />
+            </RouteGuard>
+          }
+        />
+        <Route
+          path="/clinics"
+          element={
+            <RouteGuard allowedRoles={['SystemAdmin']}>
+              <ClinicManagement />
             </RouteGuard>
           }
         />

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -25,6 +25,28 @@ export interface UpdateClinicConfigurationPayload {
   widgetEnabled?: boolean;
 }
 
+export interface TenantMemberSummary {
+  userId: string;
+  email: string;
+  role: Role;
+  status: 'active' | 'inactive';
+  tenantRole: Role;
+}
+
+export interface TenantAdminSummary {
+  tenantId: string;
+  name: string;
+  code: string | null;
+  createdAt: string;
+  updatedAt: string;
+  members: TenantMemberSummary[];
+}
+
+export interface CreateTenantPayload {
+  name: string;
+  code?: string | null;
+}
+
 export function getClinicConfiguration(): Promise<ClinicConfiguration> {
   return fetchJSON('/settings/clinic');
 }
@@ -37,6 +59,35 @@ export function updateClinicConfiguration(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
+}
+
+export function listAdminTenants(): Promise<TenantAdminSummary[]> {
+  return fetchJSON('/admin/tenants').then((data) => data.tenants as TenantAdminSummary[]);
+}
+
+export function createTenant(payload: CreateTenantPayload): Promise<TenantAdminSummary> {
+  return fetchJSON('/admin/tenants', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).then((data) => data.tenant as TenantAdminSummary);
+}
+
+export function addTenantMember(
+  tenantId: string,
+  payload: { userId: string },
+): Promise<TenantMemberSummary> {
+  return fetchJSON(`/admin/tenants/${tenantId}/members`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).then((data) => data.member as TenantMemberSummary);
+}
+
+export function removeTenantMember(tenantId: string, userId: string): Promise<void> {
+  return fetchJSON(`/admin/tenants/${tenantId}/members/${userId}`, {
+    method: 'DELETE',
+  }).then(() => undefined);
 }
 
 export interface Patient {

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -8,6 +8,7 @@ import TenantPicker from './TenantPicker';
 import GlobalSearch from './GlobalSearch';
 import { AvatarIcon, ChevronDownIcon, MenuIcon } from './icons';
 import { useTranslation } from '../hooks/useTranslation';
+import { ROLE_LABELS } from '../constants/roles';
 
 interface AppHeaderProps {
   title: string;
@@ -16,19 +17,6 @@ interface AppHeaderProps {
   onOpenMobileNav?: () => void;
   isMobileNavOpen?: boolean;
 }
-
-const ROLE_LABELS: Record<string, string> = {
-  Doctor: 'Doctor',
-  AdminAssistant: 'Administrative Assistant',
-  Cashier: 'Cashier',
-  ITAdmin: 'IT Administrator',
-  SystemAdmin: 'System Administrator',
-  Pharmacist: 'Pharmacist',
-  PharmacyTech: 'Pharmacy Technician',
-  InventoryManager: 'Inventory Manager',
-  Nurse: 'Nurse',
-  LabTech: 'Laboratory Technician',
-};
 
 const placeholderLogo = (name: string) =>
   name

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -1,11 +1,22 @@
 import { useState, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import { Link } from 'react-router-dom';
-import { AvatarIcon, CalendarIcon, CloseIcon, DashboardIcon, PatientsIcon, PharmacyIcon, ReportsIcon, SettingsIcon } from './icons';
+import {
+  AvatarIcon,
+  CalendarIcon,
+  ClinicIcon,
+  CloseIcon,
+  DashboardIcon,
+  PatientsIcon,
+  PharmacyIcon,
+  ReportsIcon,
+  SettingsIcon,
+} from './icons';
 import { useAuth } from '../context/AuthProvider';
 import { useSettings } from '../context/SettingsProvider';
 import { useTranslation } from '../hooks/useTranslation';
 import AppHeader from './AppHeader';
 import LogoutButton from './LogoutButton';
+import { ROLE_LABELS } from '../constants/roles';
 
 type NavigationKey =
   | 'dashboard'
@@ -15,6 +26,7 @@ type NavigationKey =
   | 'pharmacy'
   | 'lab'
   | 'reports'
+  | 'clinics'
   | 'settings';
 
 type NavigationItem = {
@@ -32,6 +44,7 @@ const navigation: NavigationItem[] = [
   { key: 'pharmacy', name: 'Pharmacy', icon: PharmacyIcon, to: '/pharmacy/queue' },
   { key: 'lab', name: 'Lab Orders', icon: ReportsIcon, to: '/lab-orders' },
   { key: 'reports', name: 'Reports', icon: ReportsIcon, to: '/reports' },
+  { key: 'clinics', name: 'Clinics', icon: ClinicIcon, to: '/clinics' },
   { key: 'settings', name: 'Settings', icon: SettingsIcon, to: '/settings' },
 ];
 
@@ -55,6 +68,9 @@ export default function DashboardLayout({
   const { t } = useTranslation();
   const roleLabel = user ? t(ROLE_LABELS[user.role] ?? 'Team Member') : t('Team Member');
   const navItems = navigation.filter((item) => {
+    if (item.key === 'clinics') {
+      return user?.role === 'SystemAdmin';
+    }
     if (item.key === 'settings') {
       return user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
     }
@@ -205,16 +221,3 @@ export default function DashboardLayout({
 }
 
 export type { NavigationKey };
-
-const ROLE_LABELS: Record<string, string> = {
-  Doctor: 'Doctor',
-  AdminAssistant: 'Administrative Assistant',
-  Cashier: 'Cashier',
-  ITAdmin: 'IT Administrator',
-  SystemAdmin: 'System Administrator',
-  Pharmacist: 'Pharmacist',
-  PharmacyTech: 'Pharmacy Technician',
-  InventoryManager: 'Inventory Manager',
-  Nurse: 'Nurse',
-  LabTech: 'Laboratory Technician',
-};

--- a/client/src/components/icons.tsx
+++ b/client/src/components/icons.tsx
@@ -24,6 +24,20 @@ export function PatientsIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function ClinicIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5.25 21.75a.75.75 0 01-.75-.75V9.75L12 3l7.5 6.75V21a.75.75 0 01-.75.75z"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 21.75V15a.75.75 0 01.75-.75h6a.75.75 0 01.75.75v6.75" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 13.5h3M12 12v3" />
+    </svg>
+  );
+}
+
 export function CalendarIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>

--- a/client/src/constants/roles.ts
+++ b/client/src/constants/roles.ts
@@ -1,0 +1,27 @@
+import type { Role } from '../api/client';
+
+export const ROLE_LABELS: Record<Role, string> = {
+  Doctor: 'Doctor',
+  AdminAssistant: 'Administrative Assistant',
+  Cashier: 'Cashier',
+  ITAdmin: 'IT Administrator',
+  SystemAdmin: 'System Administrator',
+  Pharmacist: 'Pharmacist',
+  PharmacyTech: 'Pharmacy Technician',
+  InventoryManager: 'Inventory Manager',
+  Nurse: 'Nurse',
+  LabTech: 'Laboratory Technician',
+};
+
+export const STAFF_ROLES: Role[] = [
+  'AdminAssistant',
+  'Cashier',
+  'ITAdmin',
+  'Pharmacist',
+  'PharmacyTech',
+  'InventoryManager',
+  'Nurse',
+  'LabTech',
+];
+
+export const CLINICALLY_GLOBAL_ROLES: Role[] = ['Doctor', 'SystemAdmin'];

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -251,3 +251,37 @@ Inventory updated.,Inventory updated.,စတော့ကို ပြင်ဆ�
 Updating…,Updating…,အပ်ဒိတ်လုပ်နေပါသည်...
 Apply adjustments,Apply adjustments,ပြင်ဆင်မှုများကို အတည်ပြုပါ
 Select a medication to begin managing inventory.,Select a medication to begin managing inventory.,စတော့စီမံမှု စတင်ရန် ဆေးဝါးတစ်မျိုးကို ရွေးချယ်ပါ။
+Clinic management,Clinic management,Clinic management
+Create clinics and assign administrative staff.,Create clinics and assign administrative staff.,Create clinics and assign administrative staff.
+Create a new clinic,Create a new clinic,Create a new clinic
+Add a clinic to begin assigning IT administrators and support staff.,Add a clinic to begin assigning IT administrators and support staff.,Add a clinic to begin assigning IT administrators and support staff.
+Clinic name,Clinic name,Clinic name
+e.g., Downtown Health Clinic,e.g., Downtown Health Clinic,e.g., Downtown Health Clinic
+Clinic code (optional),Clinic code (optional),Clinic code (optional)
+Short identifier for reports,Short identifier for reports,Short identifier for reports
+Creating…,Creating…,Creating…
+Create clinic,Create clinic,Create clinic
+Manage clinic teams,Manage clinic teams,Manage clinic teams
+No clinics have been created yet.,No clinics have been created yet.,No clinics have been created yet.
+Unable to load clinics.,Unable to load clinics.,Unable to load clinics.
+Clinic name is required.,Clinic name is required.,Clinic name is required.
+Clinic created successfully.,Clinic created successfully.,Clinic created successfully.
+Unable to create clinic.,Unable to create clinic.,Unable to create clinic.
+Clinic team updated successfully.,Clinic team updated successfully.,Clinic team updated successfully.
+Unable to update clinic staff.,Unable to update clinic staff.,Unable to update clinic staff.
+Clinic code,Clinic code,Clinic code
+Not set,Not set,Not set
+Created on {date},Created on {date},Created on {date}
+IT Administrators,IT Administrators,IT Administrators
+Assign at least one IT administrator to manage clinic access and settings.,Assign at least one IT administrator to manage clinic access and settings.,Assign at least one IT administrator to manage clinic access and settings.
+No IT administrators assigned yet.,No IT administrators assigned yet.,No IT administrators assigned yet.
+Select an IT administrator,Select an IT administrator,Select an IT administrator
+Assigning…,Assigning…,Assigning…
+Assign,Assign,Assign
+Clinic staff,Clinic staff,Clinic staff
+Add operational roles like front desk, billing, pharmacy, and nursing teams.,Add operational roles like front desk, billing, pharmacy, and nursing teams.,Add operational roles like front desk, billing, pharmacy, and nursing teams.
+No staff assigned yet.,No staff assigned yet.,No staff assigned yet.
+Select a staff member,Select a staff member,Select a staff member
+Removing…,Removing…,Removing…
+Remove,Remove,Remove
+Global roles linked to this clinic,Global roles linked to this clinic,Global roles linked to this clinic

--- a/client/src/pages/ClinicManagement.tsx
+++ b/client/src/pages/ClinicManagement.tsx
@@ -1,0 +1,435 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import DashboardLayout from '../components/DashboardLayout';
+import { useTranslation } from '../hooks/useTranslation';
+import {
+  addTenantMember,
+  createTenant,
+  listAdminTenants,
+  listUsers,
+  removeTenantMember,
+  type TenantAdminSummary,
+  type TenantMemberSummary,
+  type UserAccount,
+} from '../api/client';
+import { CLINICALLY_GLOBAL_ROLES, ROLE_LABELS, STAFF_ROLES } from '../constants/roles';
+
+interface FlashMessage {
+  type: 'success' | 'error';
+  message: string;
+}
+
+interface SelectionState {
+  [tenantId: string]: {
+    itAdmin?: string;
+    staff?: string;
+  };
+}
+
+const STAFF_ASSIGNABLE_ROLES = STAFF_ROLES.filter((role) => role !== 'ITAdmin');
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    try {
+      const parsed = JSON.parse(error.message);
+      if (parsed && typeof parsed.message === 'string') {
+        return parsed.message;
+      }
+    } catch {
+      /* ignore */
+    }
+    if (error.message) {
+      return error.message;
+    }
+  }
+  return fallback;
+}
+
+function sortMembers(members: TenantMemberSummary[]): TenantMemberSummary[] {
+  return [...members].sort((a, b) => a.email.localeCompare(b.email));
+}
+
+export default function ClinicManagement() {
+  const { t } = useTranslation();
+  const [tenants, setTenants] = useState<TenantAdminSummary[]>([]);
+  const [users, setUsers] = useState<UserAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [flash, setFlash] = useState<FlashMessage | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createForm, setCreateForm] = useState({ name: '', code: '' });
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [selection, setSelection] = useState<SelectionState>({});
+  const [assigningKey, setAssigningKey] = useState<string | null>(null);
+  const [removingKey, setRemovingKey] = useState<string | null>(null);
+
+  const staffRoleSet = useMemo(() => new Set(STAFF_ASSIGNABLE_ROLES), []);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        setLoading(true);
+        setLoadError(null);
+        const [tenantData, userData] = await Promise.all([listAdminTenants(), listUsers()]);
+        if (!active) return;
+        setTenants(tenantData.map((tenant) => ({ ...tenant, members: sortMembers(tenant.members) })));
+        setUsers(userData);
+      } catch (error) {
+        if (!active) return;
+        setLoadError(getErrorMessage(error, t('Unable to load clinics.')));
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [t]);
+
+  const handleCreateClinic = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!createForm.name.trim()) {
+      setCreateError(t('Clinic name is required.'));
+      return;
+    }
+    setCreateError(null);
+    setFlash(null);
+    setCreating(true);
+    try {
+      const payload = {
+        name: createForm.name.trim(),
+        code: createForm.code.trim() || undefined,
+      };
+      const created = await createTenant(payload);
+      setTenants((prev) => [created, ...prev]);
+      setCreateForm({ name: '', code: '' });
+      setFlash({ type: 'success', message: t('Clinic created successfully.') });
+    } catch (error) {
+      setCreateError(getErrorMessage(error, t('Unable to create clinic.')));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleSelectionChange = (tenantId: string, key: 'itAdmin' | 'staff', value: string) => {
+    setSelection((prev) => ({
+      ...prev,
+      [tenantId]: {
+        ...prev[tenantId],
+        [key]: value,
+      },
+    }));
+  };
+
+  const handleAddMember = async (tenantId: string, key: 'itAdmin' | 'staff') => {
+    const selectedUserId = selection[tenantId]?.[key];
+    if (!selectedUserId) {
+      return;
+    }
+    const operationKey = `${tenantId}:${key}`;
+    setAssigningKey(operationKey);
+    setFlash(null);
+    try {
+      const member = await addTenantMember(tenantId, { userId: selectedUserId });
+      setTenants((prev) =>
+        prev.map((tenant) =>
+          tenant.tenantId === tenantId
+            ? { ...tenant, members: sortMembers([...tenant.members, member]) }
+            : tenant,
+        ),
+      );
+      setSelection((prev) => ({
+        ...prev,
+        [tenantId]: {
+          ...prev[tenantId],
+          [key]: '',
+        },
+      }));
+      setFlash({ type: 'success', message: t('Clinic team updated successfully.') });
+    } catch (error) {
+      setFlash({ type: 'error', message: getErrorMessage(error, t('Unable to update clinic staff.')) });
+    } finally {
+      setAssigningKey(null);
+    }
+  };
+
+  const handleRemoveMember = async (tenantId: string, userId: string) => {
+    const operationKey = `${tenantId}:${userId}`;
+    setRemovingKey(operationKey);
+    setFlash(null);
+    try {
+      await removeTenantMember(tenantId, userId);
+      setTenants((prev) =>
+        prev.map((tenant) =>
+          tenant.tenantId === tenantId
+            ? { ...tenant, members: tenant.members.filter((member) => member.userId !== userId) }
+            : tenant,
+        ),
+      );
+      setFlash({ type: 'success', message: t('Clinic team updated successfully.') });
+    } catch (error) {
+      setFlash({ type: 'error', message: getErrorMessage(error, t('Unable to update clinic staff.')) });
+    } finally {
+      setRemovingKey(null);
+    }
+  };
+
+  const renderMemberList = (
+    tenantId: string,
+    members: TenantMemberSummary[],
+    emptyLabel: string,
+  ) => {
+    if (members.length === 0) {
+      return <p className="text-sm text-gray-500">{emptyLabel}</p>;
+    }
+    return (
+      <ul className="space-y-3">
+        {members.map((member) => {
+          const key = `${tenantId}:${member.userId}`;
+          const isRemoving = removingKey === key;
+          return (
+            <li
+              key={member.userId}
+              className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm"
+            >
+              <div>
+                <div className="text-sm font-semibold text-gray-900">{member.email}</div>
+                <div className="text-xs text-gray-500">{t(ROLE_LABELS[member.role])}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <span
+                  className={`text-xs font-semibold uppercase tracking-wide ${
+                    member.status === 'active' ? 'text-green-600' : 'text-gray-500'
+                  }`}
+                >
+                  {member.status === 'active' ? t('Active') : t('Inactive')}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveMember(tenantId, member.userId)}
+                  disabled={isRemoving}
+                  className="rounded-full border border-red-200 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isRemoving ? t('Removing…') : t('Remove')}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <DashboardLayout
+      title={t('Clinic management')}
+      subtitle={t('Create clinics and assign administrative staff.')}
+      activeItem="clinics"
+    >
+      <div className="space-y-8">
+        {flash && (
+          <div
+            className={`rounded-lg border px-4 py-3 text-sm ${
+              flash.type === 'success'
+                ? 'border-green-200 bg-green-50 text-green-700'
+                : 'border-red-200 bg-red-50 text-red-700'
+            }`}
+          >
+            {flash.message}
+          </div>
+        )}
+
+        <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">{t('Create a new clinic')}</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            {t('Add a clinic to begin assigning IT administrators and support staff.')}
+          </p>
+          <form className="mt-4 grid gap-4 md:grid-cols-2" onSubmit={handleCreateClinic}>
+            <div className="md:col-span-1">
+              <label className="block text-sm font-medium text-gray-700" htmlFor="clinic-name">
+                {t('Clinic name')}
+              </label>
+              <input
+                id="clinic-name"
+                type="text"
+                value={createForm.name}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, name: event.target.value }))}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                placeholder={t('e.g., Downtown Health Clinic')}
+              />
+            </div>
+            <div className="md:col-span-1">
+              <label className="block text-sm font-medium text-gray-700" htmlFor="clinic-code">
+                {t('Clinic code (optional)')}
+              </label>
+              <input
+                id="clinic-code"
+                type="text"
+                value={createForm.code}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, code: event.target.value }))}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                placeholder={t('Short identifier for reports')}
+              />
+            </div>
+            <div className="md:col-span-2 flex items-center gap-4">
+              <button
+                type="submit"
+                className="rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={creating}
+              >
+                {creating ? t('Creating…') : t('Create clinic')}
+              </button>
+              {createError && <p className="text-sm text-red-600">{createError}</p>}
+            </div>
+          </form>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-lg font-semibold text-gray-900">{t('Manage clinic teams')}</h2>
+          {loading ? (
+            <div className="rounded-xl border border-gray-200 bg-white px-6 py-8 text-center text-sm text-gray-500 shadow-sm">
+              {t('Loading clinics...')}
+            </div>
+          ) : loadError ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-6 py-4 text-sm text-red-700 shadow-sm">
+              {loadError}
+            </div>
+          ) : tenants.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-white px-6 py-8 text-center text-sm text-gray-500 shadow-sm">
+              {t('No clinics have been created yet.')}
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {tenants.map((tenant) => {
+                const assignedUserIds = new Set(tenant.members.map((member) => member.userId));
+                const availableItAdmins = users.filter(
+                  (user) => user.role === 'ITAdmin' && !assignedUserIds.has(user.userId),
+                );
+                const availableStaff = users.filter(
+                  (user) => staffRoleSet.has(user.role) && user.role !== 'ITAdmin' && !assignedUserIds.has(user.userId),
+                );
+                const itMembers = tenant.members.filter((member) => member.tenantRole === 'ITAdmin');
+                const staffMembers = tenant.members.filter(
+                  (member) =>
+                    member.tenantRole !== 'ITAdmin' && !CLINICALLY_GLOBAL_ROLES.includes(member.tenantRole),
+                );
+                const otherMembers = tenant.members.filter((member) =>
+                  CLINICALLY_GLOBAL_ROLES.includes(member.tenantRole),
+                );
+                const selectionState = selection[tenant.tenantId] ?? { itAdmin: '', staff: '' };
+                const assigningIt = assigningKey === `${tenant.tenantId}:itAdmin`;
+                const assigningStaff = assigningKey === `${tenant.tenantId}:staff`;
+
+                return (
+                  <div key={tenant.tenantId} className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                    <div className="flex flex-col gap-2 border-b border-gray-200 pb-4 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <h3 className="text-base font-semibold text-gray-900">{tenant.name}</h3>
+                        <p className="text-xs uppercase tracking-wide text-gray-500">
+                          {t('Clinic code')}: {tenant.code || t('Not set')}
+                        </p>
+                      </div>
+                      <p className="text-xs text-gray-500">
+                        {t('Created on {date}', {
+                          date: new Date(tenant.createdAt).toLocaleDateString(),
+                        })}
+                      </p>
+                    </div>
+
+                    <div className="mt-4 grid gap-6 md:grid-cols-2">
+                      <div>
+                        <h4 className="text-sm font-semibold text-gray-900">{t('IT Administrators')}</h4>
+                        <p className="mt-1 text-xs text-gray-500">
+                          {t('Assign at least one IT administrator to manage clinic access and settings.')}
+                        </p>
+                        <div className="mt-4 space-y-4">
+                          {renderMemberList(tenant.tenantId, itMembers, t('No IT administrators assigned yet.'))}
+                          <div className="flex flex-col gap-3 sm:flex-row">
+                            <label className="sr-only" htmlFor={`it-${tenant.tenantId}`}>
+                              {t('Select an IT administrator')}
+                            </label>
+                            <select
+                              id={`it-${tenant.tenantId}`}
+                              className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                              value={selectionState.itAdmin ?? ''}
+                              onChange={(event) => handleSelectionChange(tenant.tenantId, 'itAdmin', event.target.value)}
+                            >
+                              <option value="">{t('Select an IT administrator')}</option>
+                              {availableItAdmins.map((user) => (
+                                <option key={user.userId} value={user.userId}>
+                                  {user.email}
+                                </option>
+                              ))}
+                            </select>
+                            <button
+                              type="button"
+                              onClick={() => handleAddMember(tenant.tenantId, 'itAdmin')}
+                              disabled={!selectionState.itAdmin || assigningIt}
+                              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                              {assigningIt ? t('Assigning…') : t('Assign')}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <h4 className="text-sm font-semibold text-gray-900">{t('Clinic staff')}</h4>
+                        <p className="mt-1 text-xs text-gray-500">
+                          {t('Add operational roles like front desk, billing, pharmacy, and nursing teams.')}
+                        </p>
+                        <div className="mt-4 space-y-4">
+                          {renderMemberList(tenant.tenantId, staffMembers, t('No staff assigned yet.'))}
+                          <div className="flex flex-col gap-3 sm:flex-row">
+                            <label className="sr-only" htmlFor={`staff-${tenant.tenantId}`}>
+                              {t('Select a staff member')}
+                            </label>
+                            <select
+                              id={`staff-${tenant.tenantId}`}
+                              className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                              value={selectionState.staff ?? ''}
+                              onChange={(event) => handleSelectionChange(tenant.tenantId, 'staff', event.target.value)}
+                            >
+                              <option value="">{t('Select a staff member')}</option>
+                              {availableStaff.map((user) => (
+                                <option key={user.userId} value={user.userId}>
+                                  {user.email} · {t(ROLE_LABELS[user.role])}
+                                </option>
+                              ))}
+                            </select>
+                            <button
+                              type="button"
+                              onClick={() => handleAddMember(tenant.tenantId, 'staff')}
+                              disabled={!selectionState.staff || assigningStaff}
+                              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                              {assigningStaff ? t('Assigning…') : t('Assign')}
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    {otherMembers.length > 0 && (
+                      <div className="mt-6 rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-xs text-blue-700">
+                        <p className="font-semibold">{t('Global roles linked to this clinic')}</p>
+                        <p className="mt-1">
+                          {otherMembers
+                            .map((member) => `${member.email} (${t(ROLE_LABELS[member.tenantRole])})`)
+                            .join(', ')}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
   type Role,
 } from '../api/client';
 import { useAuth } from '../context/AuthProvider';
+import { ROLE_LABELS } from '../constants/roles';
 
 type DoctorFormState = {
   name: string;
@@ -20,19 +21,6 @@ type UserDraft = {
   role: Role;
   status: 'active' | 'inactive';
   doctorId: string | null;
-};
-
-const ROLE_LABELS: Record<Role, string> = {
-  Doctor: 'Doctor',
-  AdminAssistant: 'Administrative Assistant',
-  Cashier: 'Cashier',
-  ITAdmin: 'IT Administrator',
-  SystemAdmin: 'System Administrator',
-  Pharmacist: 'Pharmacist',
-  PharmacyTech: 'Pharmacy Technician',
-  InventoryManager: 'Inventory Manager',
-  Nurse: 'Nurse',
-  LabTech: 'Laboratory Technician',
 };
 
 const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [

--- a/src/modules/tenants/index.ts
+++ b/src/modules/tenants/index.ts
@@ -1,0 +1,246 @@
+import { Router, type NextFunction, type Response } from 'express';
+import type { Request } from 'express';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { z } from 'zod';
+import { requireAuth, type AuthRequest } from '../auth/index.js';
+
+const prisma = new PrismaClient();
+const router = Router();
+
+const createTenantSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  code: z.string().trim().max(32).optional(),
+});
+
+const tenantParamsSchema = z.object({
+  tenantId: z.string().uuid(),
+});
+
+const memberParamsSchema = z.object({
+  tenantId: z.string().uuid(),
+  userId: z.string().uuid(),
+});
+
+const addMemberSchema = z.object({
+  userId: z.string().uuid(),
+});
+
+router.use(requireAuth);
+router.use((req: AuthRequest, res: Response, next: NextFunction) => {
+  if (req.user?.role !== 'SystemAdmin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  return next();
+});
+
+type TenantWithMembers = Prisma.TenantGetPayload<{
+  include: {
+    userMemberships: {
+      include: {
+        user: {
+          select: {
+            userId: true,
+            email: true,
+            role: true,
+            status: true,
+          },
+        },
+      },
+    },
+  },
+}>;
+
+function slugifyName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32);
+}
+
+function normaliseStatus(value: string | null | undefined): 'active' | 'inactive' {
+  return value === 'inactive' ? 'inactive' : 'active';
+}
+
+function mapTenant(tenant: TenantWithMembers) {
+  return {
+    tenantId: tenant.tenantId,
+    name: tenant.name,
+    code: tenant.code ?? null,
+    createdAt: tenant.createdAt.toISOString(),
+    updatedAt: tenant.updatedAt.toISOString(),
+    members: tenant.userMemberships
+      .filter((membership) => membership.user)
+      .map((membership) => ({
+        userId: membership.user.userId,
+        email: membership.user.email,
+        role: membership.user.role,
+        status: normaliseStatus(membership.user.status),
+        tenantRole: membership.role,
+      }))
+      .sort((a, b) => a.email.localeCompare(b.email)),
+  };
+}
+
+function mapError(error: unknown) {
+  if (error instanceof Error) {
+    if (error.message.includes('Unique constraint')) {
+      return { status: 409, message: 'Clinic code or membership already exists' };
+    }
+  }
+  return { status: 500, message: 'Unexpected error' };
+}
+
+router.get('/', async (_req: AuthRequest, res: Response) => {
+  const tenants = await prisma.tenant.findMany({
+    orderBy: { createdAt: 'desc' },
+    include: {
+      userMemberships: {
+        include: {
+          user: {
+            select: {
+              userId: true,
+              email: true,
+              role: true,
+              status: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  res.json({ tenants: tenants.map(mapTenant) });
+});
+
+router.post('/', async (req: AuthRequest, res: Response) => {
+  const parsed = createTenantSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const { name } = parsed.data;
+  const codeInput = parsed.data.code?.trim();
+  const generatedCode = slugifyName(name);
+  const finalCode = (codeInput && codeInput.length > 0 ? codeInput : generatedCode) || null;
+
+  try {
+    const tenant = await prisma.tenant.create({
+      data: {
+        name: name.trim(),
+        code: finalCode ?? undefined,
+      },
+      include: {
+        userMemberships: {
+          include: {
+            user: {
+              select: {
+                userId: true,
+                email: true,
+                role: true,
+                status: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    res.status(201).json({ tenant: mapTenant(tenant) });
+  } catch (error) {
+    const mapped = mapError(error);
+    res.status(mapped.status).json({ error: mapped.message });
+  }
+});
+
+router.post('/:tenantId/members', async (req: Request, res: Response) => {
+  const params = tenantParamsSchema.safeParse(req.params);
+  if (!params.success) {
+    return res.status(400).json({ error: 'Invalid clinic identifier' });
+  }
+
+  const body = addMemberSchema.safeParse(req.body);
+  if (!body.success) {
+    return res.status(400).json({ error: body.error.flatten() });
+  }
+
+  const { tenantId } = params.data;
+  const { userId } = body.data;
+
+  const tenant = await prisma.tenant.findUnique({ where: { tenantId }, select: { tenantId: true } });
+  if (!tenant) {
+    return res.status(404).json({ error: 'Clinic not found' });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { userId },
+    select: { userId: true, role: true, status: true },
+  });
+
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  try {
+    const created = await prisma.userTenant.create({
+      data: {
+        tenantId,
+        userId,
+        role: user.role,
+      },
+      select: {
+        role: true,
+        user: {
+          select: {
+            userId: true,
+            email: true,
+            role: true,
+            status: true,
+          },
+        },
+      },
+    });
+
+    res.status(201).json({
+      member: {
+        userId: created.user.userId,
+        email: created.user.email,
+        role: created.user.role,
+        status: normaliseStatus(created.user.status),
+        tenantRole: created.role,
+      },
+    });
+  } catch (error) {
+    const mapped = mapError(error);
+    res.status(mapped.status).json({ error: mapped.message });
+  }
+});
+
+router.delete('/:tenantId/members/:userId', async (req: Request, res: Response) => {
+  const params = memberParamsSchema.safeParse(req.params);
+  if (!params.success) {
+    return res.status(400).json({ error: 'Invalid membership identifier' });
+  }
+
+  const { tenantId, userId } = params.data;
+
+  try {
+    const membership = await prisma.userTenant.findUnique({
+      where: { tenantId_userId: { tenantId, userId } },
+    });
+
+    if (!membership) {
+      return res.status(404).json({ error: 'Membership not found' });
+    }
+
+    await prisma.userTenant.delete({ where: { tenantId_userId: { tenantId, userId } } });
+
+    res.json({ success: true });
+  } catch (error) {
+    const mapped = mapError(error);
+    res.status(mapped.status).json({ error: mapped.message });
+  }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import meRouter from './routes/me.js';
 import patientTenantsRouter from './routes/patientTenants.js';
 import searchRouter from './routes/search.js';
 import settingsRouter from './modules/settings/index.js';
+import adminTenantsRouter from './modules/tenants/index.js';
 
 export const apiRouter = Router();
 
@@ -47,6 +48,7 @@ apiRouter.use('/me', meRouter);
 apiRouter.use(patientTenantsRouter);
 apiRouter.use('/search', searchRouter);
 apiRouter.use('/settings', settingsRouter);
+apiRouter.use('/admin/tenants', adminTenantsRouter);
 apiRouter.use(docsRouter);
 
 export default apiRouter;


### PR DESCRIPTION
## Summary
- add shared role constants for reusing staff role labels across the app
- implement a system admin clinic management page for creating clinics and assigning IT administrators and staff
- add admin tenant API routes and navigation so system admins can manage clinic memberships

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68db6f40c2a0832e87046b070d9f7b21