### PR TITLE
Fix available staff filtering for Clinic Management

### DIFF
--- a/client/src/pages/ClinicManagement.tsx
+++ b/client/src/pages/ClinicManagement.tsx
@@ -308,9 +308,12 @@ export default function ClinicManagement() {
                 const availableItAdmins = users.filter(
                   (user) => user.role === 'ITAdmin' && !assignedUserIds.has(user.userId),
                 );
-                const availableStaff = users.filter(
-                  (user) => staffRoleSet.has(user.role) && user.role !== 'ITAdmin' && !assignedUserIds.has(user.userId),
-                );
+                  const availableStaff = users.filter(
+                    (user) =>
+                      user.role !== 'ITAdmin' &&
+                      staffRoleSet.has(user.role) &&
+                      !assignedUserIds.has(user.userId),
+                  );
                 const itMembers = tenant.members.filter((member) => member.tenantRole === 'ITAdmin');
                 const staffMembers = tenant.members.filter(
                   (member) =>


### PR DESCRIPTION
## Summary
- ensure the clinic staff filter excludes IT admins before checking role membership
- keep the available staff list TypeScript-safe for tenant assignments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7e09ea38832e87f72d4e8ed7049a