### PR TITLE
Support super admin onboarding and permissions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,15 +28,28 @@ import ClinicManagement from './pages/ClinicManagement';
 import './styles/App.css';
 import { TenantProvider, useTenant } from './contexts/TenantContext';
 import TenantPicker from './components/TenantPicker';
+import SuperAdminTenantSetup from './components/SuperAdminTenantSetup';
+import { useAuth } from './context/AuthProvider';
 
 function TenantOverlays() {
   const location = useLocation();
   const { activeTenant, tenants, isLoading } = useTenant();
+  const { user } = useAuth();
+
+  const isSuperAdmin = user?.role === 'SuperAdmin';
 
   const isLoginRoute = location.pathname === '/login';
   const showLoading = isLoading && !isLoginRoute;
-  const showTenantPicker = !isLoginRoute && !isLoading && tenants.length > 1 && !activeTenant;
-  const showNoTenants = !isLoginRoute && !isLoading && tenants.length === 0 && !activeTenant;
+  const showSuperAdminSetup =
+    isSuperAdmin && !isLoginRoute && !isLoading && tenants.length === 0 && !activeTenant;
+  const showTenantPicker =
+    !isLoginRoute &&
+    !isLoading &&
+    tenants.length > 0 &&
+    !activeTenant &&
+    (tenants.length > 1 || isSuperAdmin);
+  const showNoTenants =
+    !isLoginRoute && !isLoading && tenants.length === 0 && !activeTenant && !isSuperAdmin;
 
   return (
     <>
@@ -47,7 +60,8 @@ function TenantOverlays() {
           </div>
         </div>
       )}
-      {showTenantPicker && <TenantPicker />}
+      {showSuperAdminSetup && <SuperAdminTenantSetup />}
+      {showTenantPicker && <TenantPicker forceOpen={isSuperAdmin} />}
       {showNoTenants && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/70 px-6 text-center">
           <div className="max-w-md rounded-2xl bg-white px-8 py-10 shadow-xl">
@@ -86,7 +100,7 @@ function AppContent() {
         <Route
           path="/patients/:patientId/problems"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <ProblemList />
             </RouteGuard>
           }
@@ -94,7 +108,7 @@ function AppContent() {
         <Route
           path="/appointments"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin', 'SuperAdmin']}>
               <AppointmentsPage />
             </RouteGuard>
           }
@@ -110,7 +124,7 @@ function AppContent() {
         <Route
           path="/appointments/:id"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'AdminAssistant', 'SystemAdmin', 'SuperAdmin']}>
               <AppointmentDetail />
             </RouteGuard>
           }
@@ -134,7 +148,7 @@ function AppContent() {
         <Route
           path="/register"
           element={
-            <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['AdminAssistant', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <RegisterPatient />
             </RouteGuard>
           }
@@ -166,7 +180,7 @@ function AppContent() {
         <Route
           path="/lab-orders"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <LabOrdersPage />
             </RouteGuard>
           }
@@ -174,7 +188,7 @@ function AppContent() {
         <Route
           path="/lab-orders/:labOrderId"
           element={
-            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <LabOrderDetailPage />
             </RouteGuard>
           }
@@ -182,7 +196,7 @@ function AppContent() {
         <Route
           path="/pharmacy/queue"
           element={
-            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <PharmacyQueue />
             </RouteGuard>
           }
@@ -190,7 +204,7 @@ function AppContent() {
         <Route
           path="/pharmacy/inventory"
           element={
-            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <PharmacyInventory />
             </RouteGuard>
           }
@@ -198,7 +212,7 @@ function AppContent() {
         <Route
           path="/pharmacy/drugs/new"
           element={
-            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['InventoryManager', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <AddDrug />
             </RouteGuard>
           }
@@ -206,7 +220,7 @@ function AppContent() {
         <Route
           path="/billing/workspace"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin', 'Doctor', 'Pharmacist']}>
               <BillingWorkspace />
             </RouteGuard>
           }
@@ -214,7 +228,7 @@ function AppContent() {
         <Route
           path="/billing/visit/:visitId"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin', 'Doctor', 'Pharmacist']}>
               <VisitBilling />
             </RouteGuard>
           }
@@ -222,7 +236,7 @@ function AppContent() {
         <Route
           path="/billing/pos"
           element={
-            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <PosList />
             </RouteGuard>
           }
@@ -238,7 +252,7 @@ function AppContent() {
         <Route
           path="/settings"
           element={
-            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <Settings />
             </RouteGuard>
           }
@@ -246,7 +260,7 @@ function AppContent() {
         <Route
           path="/clinics"
           element={
-            <RouteGuard allowedRoles={['SystemAdmin']}>
+            <RouteGuard allowedRoles={['SystemAdmin', 'SuperAdmin']}>
               <ClinicManagement />
             </RouteGuard>
           }
@@ -254,7 +268,7 @@ function AppContent() {
         <Route
           path="/settings/services"
           element={
-            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin']}>
+            <RouteGuard allowedRoles={['ITAdmin', 'SystemAdmin', 'SuperAdmin']}>
               <SettingsServices />
             </RouteGuard>
           }

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -6,6 +6,7 @@ export type Role =
   | 'Cashier'
   | 'ITAdmin'
   | 'SystemAdmin'
+  | 'SuperAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
   | 'InventoryManager'

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -50,7 +50,8 @@ export default function AppHeader({
   const userRoleLabel = user ? ROLE_LABELS[user.role] ?? user.role : t('Team Member');
   const userEmail = user?.email ?? t('Signed-in user');
   const searchArea = toolbarContent ?? <GlobalSearch />;
-  const showSettings = user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
+  const showSettings =
+    user?.role === 'ITAdmin' || user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin';
 
   const handleOpenTenantPicker = () => {
     if (tenants.length <= 1) {

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -69,26 +69,37 @@ export default function DashboardLayout({
   const roleLabel = user ? t(ROLE_LABELS[user.role] ?? 'Team Member') : t('Team Member');
   const navItems = navigation.filter((item) => {
     if (item.key === 'clinics') {
-      return user?.role === 'SystemAdmin';
+      return user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin';
     }
     if (item.key === 'settings') {
-      return user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
+      return (
+        user?.role === 'ITAdmin' || user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin'
+      );
     }
     if (item.key === 'billing') {
-      return user && ['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor', 'Pharmacist'].includes(user.role);
+      return (
+        user &&
+        ['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin', 'Doctor', 'Pharmacist'].includes(user.role)
+      );
     }
     if (item.key === 'pharmacy') {
       return (
-        user && ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+        user &&
+        ['Pharmacist', 'PharmacyTech', 'InventoryManager', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(
+          user.role,
+        )
       );
     }
     if (item.key === 'lab') {
-      return user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role);
+      return (
+        user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role)
+      );
     }
     return true;
   });
   const displayName = appName || t('EMR System');
-  const showSettings = user?.role === 'ITAdmin' || user?.role === 'SystemAdmin';
+  const showSettings =
+    user?.role === 'ITAdmin' || user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin';
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const userEmail = user?.email ?? t('Signed-in user');
 

--- a/client/src/components/RouteGuard.tsx
+++ b/client/src/components/RouteGuard.tsx
@@ -23,7 +23,8 @@ export default function RouteGuard({ children, allowedRoles }: Props) {
     allowedRoles &&
     !allowedRoles.includes(user.role) &&
     user.role !== 'ITAdmin' &&
-    user.role !== 'SystemAdmin'
+    user.role !== 'SystemAdmin' &&
+    user.role !== 'SuperAdmin'
   ) {
     return <Navigate to="/" replace />;
   }

--- a/client/src/components/SuperAdminTenantSetup.tsx
+++ b/client/src/components/SuperAdminTenantSetup.tsx
@@ -1,0 +1,120 @@
+import { FormEvent, useState } from 'react';
+import { createTenant } from '../api/client';
+import { useTenant } from '../contexts/TenantContext';
+import { useTranslation } from '../hooks/useTranslation';
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    try {
+      const parsed = JSON.parse(error.message) as { message?: string };
+      if (parsed?.message) {
+        return parsed.message;
+      }
+    } catch {
+      /* ignore JSON parse errors */
+    }
+    return error.message;
+  }
+  return fallback;
+}
+
+export default function SuperAdminTenantSetup() {
+  const { setActiveTenant, refreshTenants, isSwitching } = useTenant();
+  const { t } = useTranslation();
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim()) {
+      setError(t('Clinic name is required.'));
+      return;
+    }
+
+    setError(null);
+    setSuccess(null);
+    setIsSubmitting(true);
+
+    try {
+      const created = await createTenant({
+        name: name.trim(),
+        code: code.trim() || undefined,
+      });
+
+      setSuccess(t('Clinic created successfully. Switching to clinic...'));
+      await refreshTenants();
+      await setActiveTenant(created.tenantId);
+      setName('');
+      setCode('');
+    } catch (err) {
+      setError(extractErrorMessage(err, t('Unable to create clinic. Please try again.')));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const disabled = isSubmitting || isSwitching;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-6 py-12">
+      <div className="w-full max-w-lg rounded-2xl bg-white p-10 shadow-2xl">
+        <div className="mb-6 text-center">
+          <h2 className="text-2xl font-semibold text-slate-900">{t('Create your first clinic')}</h2>
+          <p className="mt-2 text-sm text-slate-500">
+            {t('Before you can continue, set up a clinic to manage. You can always add more later.')}
+          </p>
+        </div>
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+            {success}
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="clinic-name">
+              {t('Clinic name')}
+            </label>
+            <input
+              id="clinic-name"
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              placeholder={t('e.g. Sunrise Family Clinic')}
+              disabled={disabled}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="clinic-code">
+              {t('Clinic code (optional)')}
+            </label>
+            <input
+              id="clinic-code"
+              type="text"
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              placeholder={t('Short code for URLs and identification')}
+              disabled={disabled}
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-indigo-300"
+            disabled={disabled}
+          >
+            {disabled ? t('Saving...') : t('Create clinic')}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/TenantPicker.tsx
+++ b/client/src/components/TenantPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTenant } from '../contexts/TenantContext';
+import { ROLE_LABELS } from '../constants/roles';
 
 const placeholderLogo = (name: string) =>
   name
@@ -84,10 +85,10 @@ const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose 
                     {tenant.name}
                   </span>
                   <span className="mt-1 block text-sm text-slate-500">
-                    Role: {tenant.role}
+                    Role: {ROLE_LABELS[tenant.role] ?? tenant.role}
                   </span>
                   <span className="mt-1 block text-xs uppercase tracking-wide text-slate-400">
-                    {tenant.code}
+                    {tenant.code || '—'}
                   </span>
                 </span>
                 <span className="text-sm font-medium text-indigo-600">

--- a/client/src/components/VitalsCard.tsx
+++ b/client/src/components/VitalsCard.tsx
@@ -30,7 +30,7 @@ export default function VitalsCard({ patientId, defaultVisitId = '', limit = 10 
   const { t } = useTranslation();
   const { user } = useAuth();
   const canRecord = useMemo(
-    () => user && ['Nurse', 'Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    () => user && ['Nurse', 'Doctor', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role),
     [user],
   );
   const [vitalsList, setVitalsList] = useState<VitalsEntry[]>([]);

--- a/client/src/constants/roles.ts
+++ b/client/src/constants/roles.ts
@@ -6,6 +6,7 @@ export const ROLE_LABELS: Record<Role, string> = {
   Cashier: 'Cashier',
   ITAdmin: 'IT Administrator',
   SystemAdmin: 'System Administrator',
+  SuperAdmin: 'Super Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',
@@ -24,4 +25,4 @@ export const STAFF_ROLES: Role[] = [
   'LabTech',
 ];
 
-export const CLINICALLY_GLOBAL_ROLES: Role[] = ['Doctor', 'SystemAdmin'];
+export const CLINICALLY_GLOBAL_ROLES: Role[] = ['Doctor', 'SystemAdmin', 'SuperAdmin'];

--- a/client/src/pages/AppointmentsPage.tsx
+++ b/client/src/pages/AppointmentsPage.tsx
@@ -198,10 +198,13 @@ function formatTimeRange(startMin: number, endMin: number) {
 export default function AppointmentsPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const userRole = user?.role ?? 'SystemAdmin';
+  const userRole = user?.role ?? 'SuperAdmin';
   const isDoctorUser = userRole === 'Doctor';
   const canCreateAppointment =
-    userRole === 'AdminAssistant' || userRole === 'ITAdmin' || userRole === 'SystemAdmin';
+    userRole === 'AdminAssistant' ||
+    userRole === 'ITAdmin' ||
+    userRole === 'SystemAdmin' ||
+    userRole === 'SuperAdmin';
   const { t } = useTranslation();
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [loading, setLoading] = useState(false);

--- a/client/src/pages/BillingWorkspace.tsx
+++ b/client/src/pages/BillingWorkspace.tsx
@@ -111,14 +111,14 @@ export default function BillingWorkspace() {
   const [patientVisitsError, setPatientVisitsError] = useState<string | null>(null);
   const [patientVisits, setPatientVisits] = useState<Visit[]>([]);
   const canCollectPayments = user
-    ? ['Cashier', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    ? ['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role)
     : false;
   const canTriggerVoid = canCollectPayments;
   const canCreateInvoices = user
-    ? ['Cashier', 'ITAdmin', 'SystemAdmin', 'Doctor'].includes(user.role)
+    ? ['Cashier', 'ITAdmin', 'SystemAdmin', 'SuperAdmin', 'Doctor'].includes(user.role)
     : false;
   const canRepostPharmacy = user
-    ? ['Pharmacist', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    ? ['Pharmacist', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role)
     : false;
 
   useEffect(() => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -55,7 +55,7 @@ export default function Home() {
     return <DoctorQueueDashboard />;
   }
 
-  if (user?.role === 'ITAdmin' || user?.role === 'SystemAdmin') {
+  if (user?.role === 'ITAdmin' || user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin') {
     return <ITAdminDashboard role={user.role} />;
   }
 
@@ -70,7 +70,7 @@ export default function Home() {
   return <TeamDashboard role={user?.role} />;
 }
 
-function ITAdminDashboard({ role = 'ITAdmin' }: { role?: 'ITAdmin' | 'SystemAdmin' }) {
+function ITAdminDashboard({ role = 'ITAdmin' }: { role?: 'ITAdmin' | 'SystemAdmin' | 'SuperAdmin' }) {
   const { accessToken } = useAuth();
   const { t } = useTranslation();
   const [usersData, setUsersData] = useState<UserAccount[] | null>(null);
@@ -208,7 +208,13 @@ function ITAdminDashboard({ role = 'ITAdmin' }: { role?: 'ITAdmin' | 'SystemAdmi
 
   return (
     <DashboardLayout
-      title={t(role === 'SystemAdmin' ? 'System Administrator Dashboard' : 'IT Administrator Dashboard')}
+      title={t(
+        role === 'SuperAdmin'
+          ? 'Super Administrator Dashboard'
+          : role === 'SystemAdmin'
+            ? 'System Administrator Dashboard'
+            : 'IT Administrator Dashboard',
+      )}
       subtitle={t('Monitor user accounts, system access, and staff setup.')}
       activeItem="dashboard"
     >
@@ -341,6 +347,7 @@ const ACCOUNT_ROLE_LABELS: Record<UserAccount['role'], string> = {
   AdminAssistant: 'Administrative Assistant',
   ITAdmin: 'IT Administrator',
   SystemAdmin: 'System Administrator',
+  SuperAdmin: 'Super Administrator',
   Pharmacist: 'Pharmacist',
   PharmacyTech: 'Pharmacy Technician',
   InventoryManager: 'Inventory Manager',

--- a/client/src/pages/LabOrderDetail.tsx
+++ b/client/src/pages/LabOrderDetail.tsx
@@ -29,7 +29,7 @@ export default function LabOrderDetailPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const canEnterResults = useMemo(
-    () => user && ['LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    () => user && ['LabTech', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role),
     [user],
   );
   const [order, setOrder] = useState<LabOrderEntry | null>(null);

--- a/client/src/pages/LabOrders.tsx
+++ b/client/src/pages/LabOrders.tsx
@@ -26,11 +26,11 @@ export default function LabOrdersPage() {
   const { user } = useAuth();
   const navigate = useNavigate();
   const canOrder = useMemo(
-    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role),
     [user],
   );
   const canView = useMemo(
-    () => user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    () => user && ['Doctor', 'LabTech', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role),
     [user],
   );
   const [orders, setOrders] = useState<LabOrderEntry[]>([]);

--- a/client/src/pages/PatientDetail.tsx
+++ b/client/src/pages/PatientDetail.tsx
@@ -168,7 +168,8 @@ export default function PatientDetail() {
     );
   }
 
-  const canViewProblems = user && ['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin'].includes(user.role);
+  const canViewProblems =
+    user && ['Doctor', 'Nurse', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role);
 
   const headerActions = (
     <div className="flex flex-col gap-2 md:flex-row md:items-center">

--- a/client/src/pages/PharmacyQueue.tsx
+++ b/client/src/pages/PharmacyQueue.tsx
@@ -20,7 +20,7 @@ export default function PharmacyQueue() {
   const [error, setError] = useState<string | null>(null);
   const canDispense = user ? ['Pharmacist', 'PharmacyTech'].includes(user.role) : false;
   const canManageInventory = user
-    ? ['InventoryManager', 'ITAdmin', 'SystemAdmin'].includes(user.role)
+    ? ['InventoryManager', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role)
     : false;
 
   const statusLabels = useMemo(

--- a/client/src/pages/ProblemList.tsx
+++ b/client/src/pages/ProblemList.tsx
@@ -24,7 +24,7 @@ export default function ProblemList() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const canEdit = useMemo(
-    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin'].includes(user.role),
+    () => user && ['Doctor', 'ITAdmin', 'SystemAdmin', 'SuperAdmin'].includes(user.role),
     [user],
   );
   const canResolve = canEdit;

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -29,6 +29,7 @@ const ROLE_OPTIONS: Array<{ value: Role; label: string }> = [
   { value: 'Cashier', label: ROLE_LABELS.Cashier },
   { value: 'ITAdmin', label: ROLE_LABELS.ITAdmin },
   { value: 'SystemAdmin', label: ROLE_LABELS.SystemAdmin },
+  { value: 'SuperAdmin', label: ROLE_LABELS.SuperAdmin },
   { value: 'Pharmacist', label: ROLE_LABELS.Pharmacist },
   { value: 'PharmacyTech', label: ROLE_LABELS.PharmacyTech },
   { value: 'InventoryManager', label: ROLE_LABELS.InventoryManager },
@@ -130,7 +131,7 @@ export default function Settings() {
   const totalDoctors = doctors.length;
   const latestDoctor = totalDoctors > 0 ? doctors[totalDoctors - 1] : undefined;
   const latestUser = totalUsers > 0 ? users[totalUsers - 1] : undefined;
-  const isSystemAdmin = user?.role === 'SystemAdmin';
+  const isSystemAdmin = user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin';
 
   useEffect(() => {
     if (!doctors.length) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ enum Role {
   Cashier
   ITAdmin
   SystemAdmin
+  SuperAdmin
   Pharmacist
   PharmacyTech
   InventoryManager

--- a/src/middleware/requireTenantRoles.ts
+++ b/src/middleware/requireTenantRoles.ts
@@ -13,13 +13,20 @@ export function requireTenantRoles(...roles: Role[]) {
       }
 
       const tenantId = req.tenantId;
+      const privilegedRoles: Role[] = ['ITAdmin', 'SystemAdmin', 'SuperAdmin'];
+      const isPrivilegedRole = privilegedRoles.includes(user.role as Role);
+
       if (!tenantId) {
+        if (user.role === 'SuperAdmin') {
+          req.tenantRole = 'SuperAdmin';
+          return next();
+        }
         return res.status(400).json({ error: 'Tenant context missing' });
       }
 
       if (
-        (user.role === 'ITAdmin' || user.role === 'SystemAdmin') &&
-        (roles.length === 0 || roles.includes('ITAdmin') || roles.includes('SystemAdmin'))
+        isPrivilegedRole &&
+        (roles.length === 0 || roles.some((role) => privilegedRoles.includes(role)))
       ) {
         req.tenantRole = user.role as RoleName;
         return next();

--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -91,6 +91,7 @@ export async function resolveTenant(req: AuthRequest, res: Response, next: NextF
       return next();
     }
 
+    const isSuperAdmin = req.user?.role === 'SuperAdmin';
     const tokenTenantId = await resolveTenantIdFromToken(req);
     if (tokenTenantId) {
       const verifiedTenantId = await ensureTenantExistsById(tokenTenantId);
@@ -118,8 +119,13 @@ export async function resolveTenant(req: AuthRequest, res: Response, next: NextF
       ? await ensureTenantExistsById(DEFAULT_TENANT_ID)
       : await findTenantIdByCode(DEFAULT_TENANT_CODE);
 
-    if (fallbackTenantId && shouldUseDefault) {
+    if (fallbackTenantId && shouldUseDefault && !isSuperAdmin) {
       req.tenantId = fallbackTenantId;
+      return next();
+    }
+
+    if (isSuperAdmin) {
+      req.tenantId = undefined;
       return next();
     }
 

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -10,6 +10,7 @@ export type RoleName =
   | 'Cashier'
   | 'ITAdmin'
   | 'SystemAdmin'
+  | 'SuperAdmin'
   | 'Pharmacist'
   | 'PharmacyTech'
   | 'InventoryManager'
@@ -136,7 +137,7 @@ export function requireRole(...roles: RoleName[]) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    if (user.role === 'ITAdmin' || user.role === 'SystemAdmin') {
+    if (user.role === 'ITAdmin' || user.role === 'SystemAdmin' || user.role === 'SuperAdmin') {
       return next();
     }
 

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -78,10 +78,10 @@ router.get('/clinic', requireTenantRoles(), async (req: AuthRequest, res: Respon
 
 router.patch(
   '/clinic',
-  requireRole('SystemAdmin'),
+  requireRole('SystemAdmin', 'SuperAdmin'),
   requireTenantRoles(),
   async (req: AuthRequest, res: Response) => {
-    if (req.user?.role !== 'SystemAdmin') {
+    if (req.user?.role !== 'SystemAdmin' && req.user?.role !== 'SuperAdmin') {
       return res.status(403).json({ error: 'Forbidden' });
     }
 

--- a/src/modules/tenants/index.ts
+++ b/src/modules/tenants/index.ts
@@ -27,7 +27,7 @@ const addMemberSchema = z.object({
 
 router.use(requireAuth);
 router.use((req: AuthRequest, res: Response, next: NextFunction) => {
-  if (req.user?.role !== 'SystemAdmin') {
+  if (req.user?.role !== 'SystemAdmin' && req.user?.role !== 'SuperAdmin') {
     return res.status(403).json({ error: 'Forbidden' });
   }
   return next();

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -14,6 +14,7 @@ const roleSchema = z.enum([
   'Cashier',
   'ITAdmin',
   'SystemAdmin',
+  'SuperAdmin',
   'Pharmacist',
   'PharmacyTech',
   'InventoryManager',

--- a/src/routes/appointments.ts
+++ b/src/routes/appointments.ts
@@ -341,7 +341,8 @@ router.patch(
         (targetStatus === 'InProgress' || targetStatus === 'Completed') &&
         user.role !== 'Doctor' &&
         user.role !== 'ITAdmin' &&
-        user.role !== 'SystemAdmin'
+        user.role !== 'SystemAdmin' &&
+        user.role !== 'SuperAdmin'
       ) {
         throw new ForbiddenError('Only doctors can start or complete visits');
       }


### PR DESCRIPTION
## Summary
- introduce a SuperAdmin role to the backend schema and authentication guards so it can manage tenants without existing memberships
- add a guided onboarding overlay that lets super admins create the first clinic and reuse the tenant picker when clinics already exist
- update front-end route guards, dashboards, and settings so super admins inherit IT admin capabilities across the app

## Testing
- npm run lint *(fails: ESLint is not yet configured with the new flat config format)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf7b84e3c832e98a7976207000533