### PR TITLE
Fix tenant refresh after login

### DIFF
--- a/client/src/contexts/TenantContext.tsx
+++ b/client/src/contexts/TenantContext.tsx
@@ -60,7 +60,7 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [isSwitching, setIsSwitching] = useState(false);
   const [initialised, setInitialised] = useState(false);
-  const { user } = useAuth();
+  const { user, accessToken } = useAuth();
   const isSuperAdmin = user?.role === 'SuperAdmin';
 
   const setActiveTenant = useCallback(async (tenantId: string) => {
@@ -112,6 +112,15 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({
   const role = activeTenant?.role ?? null;
 
   const refreshTenants = useCallback(async () => {
+    if (!accessToken) {
+      setTenants([]);
+      setActiveTenantId(null);
+      persistTenantId(null);
+      setIsLoading(false);
+      setInitialised(false);
+      return;
+    }
+
     setIsLoading(true);
     try {
       let list: TenantSummary[] = [];
@@ -165,7 +174,7 @@ export const TenantProvider: React.FC<{ children: React.ReactNode }> = ({
       setIsLoading(false);
       setInitialised(true);
     }
-  }, [activeTenantId, isSuperAdmin, setActiveTenant]);
+  }, [accessToken, activeTenantId, isSuperAdmin, setActiveTenant]);
 
   useEffect(() => {
     void refreshTenants();


### PR DESCRIPTION
## Summary
- ensure the tenant provider waits for an access token before loading clinics
- clear cached tenant state when the user logs out so the next login re-initialises cleanly

## Testing
- npm run build (client)


------
https://chatgpt.com/codex/tasks/task_e_68df3c9f4b64832e865291396876f218