### PR TITLE
Allow system admins to bypass empty tenant overlay

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,7 +50,12 @@ function TenantOverlays() {
     !activeTenant &&
     (tenants.length > 1 || isSuperAdmin);
   const showNoTenants =
-    !isLoginRoute && !isLoading && tenants.length === 0 && !activeTenant && !isSuperAdmin;
+    !isLoginRoute &&
+    !isLoading &&
+    tenants.length === 0 &&
+    !activeTenant &&
+    !isSuperAdmin &&
+    !isSystemAdmin;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- stop showing the no clinic modal for system administrators so they can reach clinic management

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68df90580cc4832e8aa4f50560514df6