### PR TITLE
Allow privileged admins to bypass tenant requirement

### DIFF
--- a/src/middleware/requireTenantRoles.ts
+++ b/src/middleware/requireTenantRoles.ts
@@ -17,8 +17,8 @@ export function requireTenantRoles(...roles: Role[]) {
       const isPrivilegedRole = privilegedRoles.includes(user.role as Role);
 
       if (!tenantId) {
-        if (user.role === 'SuperAdmin') {
-          req.tenantRole = 'SuperAdmin';
+        if (isPrivilegedRole) {
+          req.tenantRole = user.role as RoleName;
           return next();
         }
         return res.status(400).json({ error: 'Tenant context missing' });


### PR DESCRIPTION
## Summary
- allow privileged administrative roles to proceed without a resolved tenant when invoking middleware that requires tenant roles

## Testing
- npm run lint *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b9ec2840832e9dba6a004ef4c391