### PR TITLE
Allow privileged admins to switch tenants without host slug

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -160,10 +160,13 @@ export async function resolveTenant(req: AuthRequest, res: Response, next: NextF
     if (slug) {
       const tenantId = await findTenantIdByCode(slug);
       if (!tenantId) {
-        return res.status(404).json({ error: 'Tenant not found' });
+        if (!isSuperAdmin && !isSystemAdmin) {
+          return res.status(404).json({ error: 'Tenant not found' });
+        }
+      } else {
+        req.tenantId = tenantId;
+        return next();
       }
-      req.tenantId = tenantId;
-      return next();
     }
 
     const host = stripPort(req.headers.host);


### PR DESCRIPTION
## Summary
- avoid returning a 404 when a privileged admin accesses the API from a host without a tenant slug
- keep the existing 404 behaviour for non-privileged users while still allowing valid slugs to resolve normally

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec279ef8832e97fa5c4627e927a5