### PR TITLE
Allow tenant switching without preselected clinic

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -3,7 +3,6 @@ import { PrismaClient, type Role } from '@prisma/client';
 import { z } from 'zod';
 
 import type { AuthRequest } from '../modules/auth/index.js';
-import { requireTenantRoles } from '../middleware/requireTenantRoles.js';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -17,8 +16,6 @@ export const exampleTenantJwtPayload = {
   tenantId: '11111111-2222-4333-8444-555555555555',
   role: 'Doctor',
 } as const;
-
-router.use(requireTenantRoles());
 
 router.post('/switch-tenant', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {


### PR DESCRIPTION
## Summary
- allow the tenant resolver to skip context resolution for session switching requests
- rely on the switch-tenant handler to enforce membership without requireTenantRoles

## Testing
- npm test *(fails: requires DATABASE_URL for Prisma)*

------
https://chatgpt.com/codex/tasks/task_e_68e0eea7813c832eb88980dd700b32a1