### PR TITLE
Allow IT admins to load clinics without tenant context

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -141,13 +141,17 @@ export async function resolveTenant(req: AuthRequest, res: Response, next: NextF
 
     const isSuperAdmin = req.user?.role === 'SuperAdmin';
     const isSystemAdmin = req.user?.role === 'SystemAdmin';
+    const isITAdmin = req.user?.role === 'ITAdmin';
 
     if (isRequestMatchingPrefixes(req, TENANT_OPTIONAL_ALL_ROLES_PREFIXES)) {
       req.tenantId = undefined;
       return next();
     }
 
-    if ((isSuperAdmin || isSystemAdmin) && isRequestMatchingPrefixes(req, TENANT_OPTIONAL_PREFIXES)) {
+    if (
+      (isSuperAdmin || isSystemAdmin || isITAdmin) &&
+      isRequestMatchingPrefixes(req, TENANT_OPTIONAL_PREFIXES)
+    ) {
       req.tenantId = undefined;
       return next();
     }


### PR DESCRIPTION
## Summary
- permit IT administrators to access tenant-optional endpoints such as `/me/tenants` without an active tenant selection
- ensure the tenant resolver treats IT admins the same as other elevated roles when loading clinic memberships

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f36252ac832ebf6ff8d9e30f7e02