### PR TITLE
Align clinic RBAC with IT administrator workflow

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -697,3 +697,20 @@ export function updateUserAccount(id: string, payload: UpdateUserPayload): Promi
     body: JSON.stringify(payload),
   });
 }
+
+export function listAssignableUsers(): Promise<UserAccount[]> {
+  return fetchJSON('/users/assignable');
+}
+
+export function assignUserToActiveTenant(userId: string): Promise<UserAccount> {
+  return fetchJSON(`/users/${userId}/tenants`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function removeUserFromActiveTenant(userId: string): Promise<void> {
+  return fetchJSON(`/users/${userId}/tenants`, {
+    method: 'DELETE',
+  }).then(() => undefined);
+}

--- a/client/src/constants/roles.ts
+++ b/client/src/constants/roles.ts
@@ -26,3 +26,14 @@ export const STAFF_ROLES: Role[] = [
 ];
 
 export const CLINICALLY_GLOBAL_ROLES: Role[] = ['Doctor', 'SystemAdmin', 'SuperAdmin'];
+
+export const CLINIC_MANAGED_ROLES: Role[] = [
+  'Doctor',
+  'AdminAssistant',
+  'Cashier',
+  'Pharmacist',
+  'PharmacyTech',
+  'InventoryManager',
+  'Nurse',
+  'LabTech',
+];

--- a/client/src/context/SettingsProvider.tsx
+++ b/client/src/context/SettingsProvider.tsx
@@ -3,10 +3,12 @@ import {
   createDoctor,
   createUserAccount,
   getClinicConfiguration,
+  assignUserToActiveTenant,
   listDoctors,
   listUsers,
   updateClinicConfiguration,
   updateUserAccount,
+  removeUserFromActiveTenant,
   type CreateUserPayload,
   type Doctor,
   type UpdateClinicConfigurationPayload,
@@ -27,6 +29,8 @@ interface SettingsContextType {
   addDoctor: (doctor: { name: string; department: string }) => Promise<Doctor>;
   widgetEnabled: boolean;
   setWidgetEnabled: (enabled: boolean) => void;
+  assignExistingUser: (userId: string) => Promise<UserAccount>;
+  removeUserFromClinic: (userId: string) => Promise<void>;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -159,6 +163,17 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     return updated;
   };
 
+  const assignExistingUser = async (userId: string) => {
+    const assigned = await assignUserToActiveTenant(userId);
+    setUsers((prev) => [...prev, assigned].sort((a, b) => a.email.localeCompare(b.email)));
+    return assigned;
+  };
+
+  const removeUserFromClinic = async (userId: string) => {
+    await removeUserFromActiveTenant(userId);
+    setUsers((prev) => prev.filter((user) => user.userId !== userId));
+  };
+
   const addDoctor = async (doctor: { name: string; department: string }) => {
     const created = await createDoctor(doctor);
     setDoctors((prev) => [...prev, created]);
@@ -182,6 +197,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         addDoctor,
         widgetEnabled,
         setWidgetEnabled,
+        assignExistingUser,
+        removeUserFromClinic,
       }}
     >
       {children}

--- a/src/modules/tenants/index.ts
+++ b/src/modules/tenants/index.ts
@@ -182,6 +182,10 @@ router.post('/:tenantId/members', async (req: Request, res: Response) => {
     return res.status(404).json({ error: 'User not found' });
   }
 
+  if (user.role !== 'ITAdmin') {
+    return res.status(400).json({ error: 'Only IT administrators can be assigned by system administrators' });
+  }
+
   try {
     const created = await prisma.userTenant.create({
       data: {

--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -1,12 +1,39 @@
 import { Router, type Response } from 'express';
 import type { Request } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, type Role } from '@prisma/client';
 import bcrypt from 'bcrypt';
 import { z } from 'zod';
-import { requireAuth, requireRole, type AuthRequest } from '../auth/index.js';
+import { requireAuth, type AuthRequest } from '../auth/index.js';
 
 const prisma = new PrismaClient();
 const router = Router();
+
+const PRIVILEGED_ROLES: Role[] = ['ITAdmin', 'SystemAdmin', 'SuperAdmin'];
+const CLINIC_MANAGED_ROLES: Role[] = [
+  'Doctor',
+  'AdminAssistant',
+  'Cashier',
+  'Pharmacist',
+  'PharmacyTech',
+  'InventoryManager',
+  'Nurse',
+  'LabTech',
+];
+
+function sortUsers<T extends { email: string }>(users: T[]): T[] {
+  return [...users].sort((a, b) => a.email.localeCompare(b.email));
+}
+
+const userSelect = {
+  userId: true,
+  email: true,
+  role: true,
+  status: true,
+  doctorId: true,
+  createdAt: true,
+  updatedAt: true,
+  doctor: { select: { doctorId: true, name: true, department: true } },
+} as const;
 
 const roleSchema = z.enum([
   'Doctor',
@@ -45,6 +72,45 @@ function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
+type ManagementContext =
+  | { type: 'system'; tenantId: string | null }
+  | { type: 'itAdmin'; tenantId: string };
+
+async function resolveManagementContext(req: AuthRequest, res: Response): Promise<ManagementContext | null> {
+  const user = req.user;
+  if (!user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+
+  if (user.role === 'SystemAdmin' || user.role === 'SuperAdmin') {
+    return { type: 'system', tenantId: req.tenantId ?? null };
+  }
+
+  if (user.role !== 'ITAdmin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+
+  const tenantId = req.tenantId;
+  if (!tenantId) {
+    res.status(400).json({ error: 'Tenant context required' });
+    return null;
+  }
+
+  const membership = await prisma.userTenant.findUnique({
+    where: { tenantId_userId: { tenantId, userId: user.userId } },
+    select: { role: true },
+  });
+
+  if (!membership || membership.role !== 'ITAdmin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return null;
+  }
+
+  return { type: 'itAdmin', tenantId };
+}
+
 async function ensureDoctorAssignment(doctorId: string, excludeUserId?: string) {
   const doctor = await prisma.doctor.findUnique({ where: { doctorId } });
   if (!doctor) {
@@ -79,26 +145,55 @@ function mapError(error: unknown) {
 }
 
 router.use(requireAuth);
-router.use(requireRole('ITAdmin'));
 
-router.get('/', async (_req: AuthRequest, res: Response) => {
-  const users = await prisma.user.findMany({
-    orderBy: { createdAt: 'asc' },
-    select: {
-      userId: true,
-      email: true,
-      role: true,
-      status: true,
-      doctorId: true,
-      createdAt: true,
-      updatedAt: true,
-      doctor: { select: { doctorId: true, name: true, department: true } },
-    },
+router.get('/', async (req: AuthRequest, res: Response) => {
+  const context = await resolveManagementContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (context.type === 'system') {
+    if (context.tenantId) {
+      const memberships = await prisma.userTenant.findMany({
+        where: { tenantId: context.tenantId },
+        include: { user: { select: userSelect } },
+      });
+      const users = sortUsers(
+        memberships
+          .filter((membership) => membership.user)
+          .map((membership) => ({ ...membership.user })),
+      );
+      res.json(users);
+      return;
+    }
+
+    const users = await prisma.user.findMany({
+      orderBy: { email: 'asc' },
+      select: userSelect,
+    });
+    res.json(users);
+    return;
+  }
+
+  const memberships = await prisma.userTenant.findMany({
+    where: { tenantId: context.tenantId },
+    include: { user: { select: userSelect } },
   });
+
+  const users = sortUsers(
+    memberships
+      .filter((membership) => membership.user)
+      .map((membership) => ({ ...membership.user })),
+  );
   res.json(users);
 });
 
 router.post('/', async (req: AuthRequest, res: Response) => {
+  const context = await resolveManagementContext(req, res);
+  if (!context) {
+    return;
+  }
+
   const parsed = createUserSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: parsed.error.flatten() });
@@ -106,6 +201,10 @@ router.post('/', async (req: AuthRequest, res: Response) => {
 
   const { email, password, role, doctorId } = parsed.data;
   const normalizedEmail = normalizeEmail(email);
+
+  if (context.type === 'itAdmin' && !CLINIC_MANAGED_ROLES.includes(role)) {
+    return res.status(403).json({ error: 'Role cannot be assigned by clinic administrators' });
+  }
 
   if (role !== 'Doctor' && typeof doctorId === 'string') {
     return res.status(400).json({ error: 'doctorId can only be set for doctor accounts' });
@@ -128,24 +227,37 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   const passwordHash = await bcrypt.hash(password, 10);
 
   try {
-    const created = await prisma.user.create({
-      data: {
-        email: normalizedEmail,
-        passwordHash,
-        role,
-        status: 'active',
-        doctorId: assignedDoctorId,
-      },
-      select: {
-        userId: true,
-        email: true,
-        role: true,
-        status: true,
-        doctorId: true,
-        createdAt: true,
-        updatedAt: true,
-        doctor: { select: { doctorId: true, name: true, department: true } },
-      },
+    const created = await prisma.$transaction(async (tx) => {
+      const createdUser = await tx.user.create({
+        data: {
+          email: normalizedEmail,
+          passwordHash,
+          role,
+          status: 'active',
+          doctorId: assignedDoctorId,
+        },
+        select: userSelect,
+      });
+
+      if (context.type === 'itAdmin') {
+        await tx.userTenant.create({
+          data: {
+            tenantId: context.tenantId,
+            userId: createdUser.userId,
+            role,
+          },
+        });
+      }
+
+      if (context.type === 'system' && context.tenantId) {
+        await tx.userTenant.upsert({
+          where: { tenantId_userId: { tenantId: context.tenantId, userId: createdUser.userId } },
+          update: { role },
+          create: { tenantId: context.tenantId, userId: createdUser.userId, role },
+        });
+      }
+
+      return createdUser;
     });
 
     res.status(201).json(created);
@@ -155,7 +267,120 @@ router.post('/', async (req: AuthRequest, res: Response) => {
   }
 });
 
+router.get('/assignable', async (req: AuthRequest, res: Response) => {
+  const context = await resolveManagementContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (context.type !== 'itAdmin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const existingMemberships = await prisma.userTenant.findMany({
+    where: { tenantId: context.tenantId },
+    select: { userId: true },
+  });
+
+  const excluded = existingMemberships.map((membership) => membership.userId);
+
+  const assignable = await prisma.user.findMany({
+    where: {
+      role: { in: CLINIC_MANAGED_ROLES },
+      userId: { notIn: excluded.length > 0 ? excluded : undefined },
+    },
+    orderBy: { email: 'asc' },
+    select: userSelect,
+  });
+
+  res.json(assignable);
+});
+
+router.post('/:id/tenants', async (req: Request, res: Response) => {
+  const context = await resolveManagementContext(req as AuthRequest, res as Response);
+  if (!context) {
+    return;
+  }
+
+  if (context.type !== 'itAdmin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const params = paramsSchema.safeParse(req.params);
+  if (!params.success) {
+    return res.status(400).json({ error: 'Invalid user identifier' });
+  }
+
+  const { id } = params.data;
+
+  const user = await prisma.user.findUnique({ where: { userId: id }, select: userSelect });
+  if (!user) {
+    return res.status(404).json({ error: 'User not found' });
+  }
+
+  if (!CLINIC_MANAGED_ROLES.includes(user.role as Role)) {
+    return res.status(403).json({ error: 'Role cannot be assigned by clinic administrators' });
+  }
+
+  const existingMembership = await prisma.userTenant.findUnique({
+    where: { tenantId_userId: { tenantId: context.tenantId, userId: id } },
+  });
+  if (existingMembership) {
+    return res.status(409).json({ error: 'User is already assigned to this clinic' });
+  }
+
+  try {
+    await prisma.userTenant.create({
+      data: { tenantId: context.tenantId, userId: id, role: user.role as Role },
+    });
+    res.status(201).json(user);
+  } catch (error) {
+    const mapped = mapError(error);
+    res.status(mapped.status).json({ error: mapped.message });
+  }
+});
+
+router.delete('/:id/tenants', async (req: Request, res: Response) => {
+  const context = await resolveManagementContext(req as AuthRequest, res as Response);
+  if (!context) {
+    return;
+  }
+
+  if (context.type !== 'itAdmin') {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  const params = paramsSchema.safeParse(req.params);
+  if (!params.success) {
+    return res.status(400).json({ error: 'Invalid user identifier' });
+  }
+
+  const { id } = params.data;
+
+  const membership = await prisma.userTenant.findUnique({
+    where: { tenantId_userId: { tenantId: context.tenantId, userId: id } },
+    select: { role: true },
+  });
+
+  if (!membership) {
+    return res.status(404).json({ error: 'Membership not found' });
+  }
+
+  if (PRIVILEGED_ROLES.includes(membership.role)) {
+    return res.status(403).json({ error: 'Cannot remove privileged clinic members' });
+  }
+
+  await prisma.userTenant.delete({ where: { tenantId_userId: { tenantId: context.tenantId, userId: id } } });
+
+  res.json({ success: true });
+});
+
 router.patch('/:id', async (req: Request, res: Response) => {
+  const context = await resolveManagementContext(req as AuthRequest, res as Response);
+  if (!context) {
+    return;
+  }
+
   const params = paramsSchema.safeParse(req.params);
   if (!params.success) {
     return res.status(400).json({ error: 'Invalid user identifier' });
@@ -170,12 +395,20 @@ router.patch('/:id', async (req: Request, res: Response) => {
   const { id } = params.data;
   const { password, role, status, doctorId } = parsed.data;
 
-  const existingUser = await prisma.user.findUnique({ where: { userId: id }, select: { role: true } });
+  const existingUser = await prisma.user.findUnique({
+    where: { userId: id },
+    select: { role: true },
+  });
   if (!existingUser) {
     return res.status(404).json({ error: 'User not found' });
   }
 
   const targetRole = role ?? existingUser.role;
+
+  if (context.type === 'itAdmin' && !CLINIC_MANAGED_ROLES.includes(targetRole)) {
+    return res.status(403).json({ error: 'Role cannot be assigned by clinic administrators' });
+  }
+
   if (targetRole !== 'Doctor' && typeof doctorId === 'string') {
     return res.status(400).json({ error: 'doctorId can only be set for doctor accounts' });
   }
@@ -190,7 +423,7 @@ router.patch('/:id', async (req: Request, res: Response) => {
     updates.status = status;
   }
 
-  if (role === 'Doctor') {
+  if (targetRole === 'Doctor') {
     const targetDoctorId = doctorId ?? null;
     if (!targetDoctorId) {
       return res.status(400).json({ error: 'doctorId is required for doctor accounts' });
@@ -209,19 +442,36 @@ router.patch('/:id', async (req: Request, res: Response) => {
   }
 
   try {
-    const updated = await prisma.user.update({
-      where: { userId: id },
-      data: updates,
-      select: {
-        userId: true,
-        email: true,
-        role: true,
-        status: true,
-        doctorId: true,
-        createdAt: true,
-        updatedAt: true,
-        doctor: { select: { doctorId: true, name: true, department: true } },
-      },
+    const updated = await prisma.$transaction(async (tx) => {
+      if (context.type === 'itAdmin') {
+        const membership = await tx.userTenant.findUnique({
+          where: { tenantId_userId: { tenantId: context.tenantId, userId: id } },
+          select: { role: true },
+        });
+
+        if (!membership) {
+          throw Object.assign(new Error('Forbidden'), { statusCode: 403 });
+        }
+      }
+
+      const updatedUser = await tx.user.update({
+        where: { userId: id },
+        data: updates,
+        select: userSelect,
+      });
+
+      if (role) {
+        if (context.type === 'itAdmin') {
+          await tx.userTenant.updateMany({
+            where: { tenantId: context.tenantId, userId: id },
+            data: { role: targetRole },
+          });
+        } else {
+          await tx.userTenant.updateMany({ where: { userId: id }, data: { role: targetRole } });
+        }
+      }
+
+      return updatedUser;
     });
 
     res.json(updated);


### PR DESCRIPTION
## Summary
- enforce tenant-aware access in the user module so IT administrators can only manage staff within their clinics, add membership assignment/removal endpoints, and keep roles in sync
- restrict clinic membership assignments to IT administrators and refresh the clinic management page to remove staff assignment controls while highlighting IT admin ownership
- extend the settings experience with assignable account support, role restrictions, and new client helpers for linking or removing staff from a clinic

## Testing
- npm run lint *(fails: ESLint configuration file is missing in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f5306dc0832eaa4313e0ca4b386a