### PR TITLE
Allow IT admins to fetch assigned tenants

### DIFF
--- a/src/middleware/tenant.ts
+++ b/src/middleware/tenant.ts
@@ -75,7 +75,7 @@ async function ensureTenantExistsById(tenantId: string): Promise<string | null> 
 }
 
 const TENANT_OPTIONAL_PREFIXES = ['/admin/tenants', '/users', '/me/tenants'];
-const TENANT_OPTIONAL_ALL_ROLES_PREFIXES = ['/sessions'];
+const TENANT_OPTIONAL_ALL_ROLES_PREFIXES = ['/sessions', '/me/tenants'];
 
 function normalizePath(value: string | undefined): string | null {
   if (!value) {


### PR DESCRIPTION
## Summary
- allow tenant resolution middleware to treat `/me/tenants` as tenant-optional for every role so IT admins can load their clinic assignments

## Testing
- npm test *(fails: Prisma requires DATABASE_URL in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a83e7554832e90260c5b2692d56d