### PR TITLE
Allow system administrators to configure any clinic

### DIFF
--- a/src/routes/sessions.ts
+++ b/src/routes/sessions.ts
@@ -55,7 +55,7 @@ router.post('/switch-tenant', async (req: AuthRequest, res: Response, next: Next
         name: membership.tenant.name,
         code: membership.tenant.code ?? null,
       };
-    } else if (user.role === 'SuperAdmin') {
+    } else if (user.role === 'SuperAdmin' || user.role === 'SystemAdmin') {
       const tenant = await prisma.tenant.findUnique({
         where: { tenantId },
         select: { tenantId: true, name: true, code: true },
@@ -65,7 +65,7 @@ router.post('/switch-tenant', async (req: AuthRequest, res: Response, next: Next
         return res.status(404).json({ error: 'Tenant not found' });
       }
 
-      tenantRole = 'SuperAdmin';
+      tenantRole = user.role as Role;
       tenantDetails = {
         tenantId: tenant.tenantId,
         name: tenant.name,


### PR DESCRIPTION
## Summary
- allow system administrators to switch their session to any clinic without being explicitly assigned as a member
- reuse the requesting administrator's role when returning the tenant session payload

## Testing
- npm test -- --runTestsByPath tests/routes/sessions.test.ts (fails: ENOENT: no such file or directory, open '/workspace/Thu-Kha-EMR-Central/tests/routes/sessions.test.ts')

------
https://chatgpt.com/codex/tasks/task_e_68e33e995d74832eb8f8bc7762958627