### PR TITLE
feat: show clinic logo next to name

### DIFF
--- a/client/src/components/ClinicBrand.tsx
+++ b/client/src/components/ClinicBrand.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+interface ClinicBrandProps {
+  name: string;
+  logo?: string | null;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  nameClassName?: string;
+}
+
+function getInitials(name: string): string {
+  return (
+    name
+      .split(' ')
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? '')
+      .join('') || '??'
+  );
+}
+
+const SIZE_DIMENSIONS: Record<NonNullable<ClinicBrandProps['size']>, string> = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-base',
+  lg: 'h-12 w-12 text-lg',
+};
+
+export default function ClinicBrand({
+  name,
+  logo = null,
+  size = 'md',
+  className = '',
+  nameClassName = 'text-base font-semibold text-gray-900',
+}: ClinicBrandProps) {
+  const dimensions = SIZE_DIMENSIONS[size];
+  const initials = getInitials(name);
+
+  const logoClasses = logo
+    ? `flex items-center justify-center rounded-lg border border-gray-200 bg-white ${dimensions}`
+    : `flex items-center justify-center rounded-lg bg-blue-100 font-semibold text-blue-700 ${dimensions}`;
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <div className={logoClasses}>
+        {logo ? (
+          <img src={logo} alt={name} className="h-full w-full rounded-lg object-cover" />
+        ) : (
+          initials
+        )}
+      </div>
+      <span className={nameClassName}>{name}</span>
+    </div>
+  );
+}

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -16,6 +16,7 @@ import { useSettings } from '../context/SettingsProvider';
 import { useTranslation } from '../hooks/useTranslation';
 import AppHeader from './AppHeader';
 import LogoutButton from './LogoutButton';
+import ClinicBrand from './ClinicBrand';
 import { ROLE_LABELS } from '../constants/roles';
 
 type NavigationKey =
@@ -152,7 +153,12 @@ export default function DashboardLayout({
   return (
     <div className="flex min-h-screen bg-gray-50">
       <aside className="hidden w-72 flex-col border-r border-gray-200 bg-white px-6 py-8 shadow-sm md:flex lg:w-80">
-        <div className="text-lg font-semibold text-blue-600">{displayName}</div>
+        <ClinicBrand
+          name={displayName}
+          logo={logo ?? undefined}
+          size="md"
+          nameClassName="text-lg font-semibold text-blue-600"
+        />
         <nav className="mt-8 space-y-1">
           <NavigationLinks />
         </nav>
@@ -177,7 +183,12 @@ export default function DashboardLayout({
           />
           <div className="relative ml-auto flex h-full w-full max-w-xs flex-col bg-white px-6 py-6 shadow-xl">
             <div className="flex items-center justify-between gap-3">
-              <span className="text-lg font-semibold text-blue-600">{displayName}</span>
+              <ClinicBrand
+                name={displayName}
+                logo={logo ?? undefined}
+                size="md"
+                nameClassName="text-lg font-semibold text-blue-600"
+              />
               <button
                 type="button"
                 onClick={() => setIsMobileNavOpen(false)}

--- a/client/src/components/LoginCard.tsx
+++ b/client/src/components/LoginCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from '../hooks/useTranslation';
+import ClinicBrand from './ClinicBrand';
 
 interface LoginCardProps {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
@@ -19,31 +20,14 @@ export default function LoginCard({
   const { t } = useTranslation();
   return (
     <div className="rounded-2xl bg-white p-6 shadow sm:p-8">
-      <div className="mb-6 flex flex-col items-center">
-        {logo ? (
-          <img
-            src={logo}
-            alt="logo"
-            className="mb-4 h-12 w-auto rounded object-contain"
-          />
-        ) : (
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-600">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-6 w-6 text-white"
-              aria-hidden="true"
-            >
-              <path d="M12 6v12M6 12h12" />
-            </svg>
-          </div>
-        )}
-        <h1 className="text-2xl font-bold text-gray-900">{appName}</h1>
+      <div className="mb-6 flex flex-col items-center gap-3">
+        <ClinicBrand
+          name={appName}
+          logo={logo ?? undefined}
+          size="lg"
+          className="justify-center"
+          nameClassName="text-2xl font-bold text-gray-900"
+        />
         <p className="mt-2 text-sm text-gray-600">{t('Sign in to your account')}</p>
       </div>
 

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
 import DashboardLayout from '../components/DashboardLayout';
+import ClinicBrand from '../components/ClinicBrand';
 import { AvatarIcon, CheckIcon, PatientsIcon, SettingsIcon } from '../components/icons';
 import { useSettings } from '../context/SettingsProvider';
 import { useTranslation, type Language } from '../hooks/useTranslation';
@@ -548,7 +549,12 @@ export default function Settings() {
               </span>
               <div>
                 <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Application</div>
-                <div className="mt-1 text-lg font-semibold text-gray-900">{appName}</div>
+                <ClinicBrand
+                  name={appName}
+                  logo={logo ?? undefined}
+                  size="sm"
+                  nameClassName="text-lg font-semibold text-gray-900"
+                />
                 <p className="text-xs text-gray-500">Visible across staff dashboard and patient portal.</p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a reusable ClinicBrand component that renders a clinic logo with fallback initials
- display the clinic logo before the clinic name across dashboard navigation, login, and settings overview cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e33fb7dae0832eb5a743c6a46efeac