### PR TITLE
Add clinic selection to settings and increase upload limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 app.use(morgan('dev'));
-app.use(express.json());
+app.use(express.json({ limit: '2mb' }));
 
 app.get('/api/health', (_req: Request, res: Response) => {
   res.json({ status: 'ok' });


### PR DESCRIPTION
## Summary
- add a clinic selector to the settings page so multi-clinic admins can quickly switch the active tenant before configuring
- guard branding actions when no clinic is active and surface clearer messaging for selection and switching states
- raise the API JSON body limit to 2MB to stop logo uploads from failing with internal server errors

## Testing
- npm run lint *(fails: ESLint requires eslint.config.js in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e346fb5cc4832eab5085f6064666ec