### PR TITLE
Fix clinic switch dialog overlay rendering

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthProvider';
 import { useSettings } from '../context/SettingsProvider';
@@ -98,11 +99,17 @@ export default function AppHeader({
     </>
   );
 
+  const tenantPickerPortal =
+    isTenantPickerOpen && typeof document !== 'undefined'
+      ? createPortal(
+          <TenantPicker forceOpen onClose={() => setIsTenantPickerOpen(false)} />,
+          document.body,
+        )
+      : null;
+
   return (
     <>
-      {isTenantPickerOpen && (
-        <TenantPicker forceOpen onClose={() => setIsTenantPickerOpen(false)} />
-      )}
+      {tenantPickerPortal}
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- render the tenant picker dialog through a portal so it is no longer clipped by the header backdrop filter
- keep the switch clinic button behaviour unchanged while ensuring the picker covers the whole viewport

## Testing
- npm run build --silent (client)

------
https://chatgpt.com/codex/tasks/task_e_68e37a93e4d4832e92ecde73f466329d