### PR TITLE
Improve tenant picker availability and messaging

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -40,6 +40,7 @@ export default function AppHeader({
   const { activeTenant, tenants, role, isSwitching } = useTenant();
   const [isTenantPickerOpen, setIsTenantPickerOpen] = useState(false);
 
+  const hasClinics = tenants.length > 0;
   const tenantInitials = useMemo(() => {
     if (activeTenant) {
       return placeholderLogo(activeTenant.name);
@@ -57,14 +58,14 @@ export default function AppHeader({
   const canSwitchTenants = tenants.length > 1;
 
   const handleOpenTenantPicker = () => {
-    if (!canSwitchTenants || isSwitching) {
+    if (!hasClinics || isSwitching) {
       return;
     }
     setIsTenantPickerOpen(true);
   };
 
   const clinicCardClassName = `flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm ${
-    canSwitchTenants
+    hasClinics
       ? 'cursor-pointer transition hover:border-blue-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500'
       : ''
   }`;
@@ -124,7 +125,7 @@ export default function AppHeader({
                 <MenuIcon className="h-5 w-5" />
               </button>
             )}
-            {canSwitchTenants ? (
+            {hasClinics ? (
               <button
                 type="button"
                 onClick={handleOpenTenantPicker}

--- a/client/src/components/TenantPicker.tsx
+++ b/client/src/components/TenantPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useTenant } from '../contexts/TenantContext';
 import { ROLE_LABELS } from '../constants/roles';
+import { useTranslation } from '../hooks/useTranslation';
 
 const placeholderLogo = (name: string) =>
   name
@@ -16,11 +17,14 @@ interface TenantPickerProps {
 }
 
 const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose }) => {
+  const { t } = useTranslation();
   const { tenants, activeTenant, setActiveTenant, isSwitching } = useTenant();
   const [error, setError] = useState<string | null>(null);
   const [pendingTenantId, setPendingTenantId] = useState<string | null>(null);
 
-  const shouldShow = forceOpen || (tenants.length > 1 && !activeTenant);
+  const hasClinics = tenants.length > 0;
+  const hasMultipleClinics = tenants.length > 1;
+  const shouldShow = forceOpen || (!activeTenant && hasClinics);
 
   if (!shouldShow) {
     return null;
@@ -51,14 +55,12 @@ const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose 
             className="absolute right-4 top-4 rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-500 hover:bg-slate-100"
             onClick={onClose}
           >
-            Close
+            {t('Close')}
           </button>
         )}
         <div className="mb-8 text-center">
-          <h2 className="text-2xl font-semibold text-slate-900">Choose your clinic</h2>
-          <p className="mt-2 text-sm text-slate-500">
-            Select which clinic you would like to work in for this session.
-          </p>
+          <h2 className="text-2xl font-semibold text-slate-900">{t('Choose your clinic')}</h2>
+          <p className="mt-2 text-sm text-slate-500">{t('Select which clinic you would like to work in for this session.')}</p>
         </div>
         {error && (
           <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -69,13 +71,14 @@ const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose 
           {tenants.map((tenant) => {
             const initials = placeholderLogo(tenant.name);
             const isPending = pendingTenantId === tenant.tenantId || isSwitching;
+            const isActive = activeTenant?.tenantId === tenant.tenantId;
             return (
               <button
                 key={tenant.tenantId}
                 type="button"
                 onClick={() => handleSelect(tenant.tenantId)}
                 className="flex w-full items-center gap-4 rounded-xl border border-slate-200 bg-white p-4 text-left transition hover:border-indigo-400 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
-                disabled={isPending}
+                disabled={isPending || isActive}
               >
                 <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-indigo-100 text-base font-semibold text-indigo-700">
                   {initials || tenant.code.toUpperCase().slice(0, 2)}
@@ -85,19 +88,28 @@ const TenantPicker: React.FC<TenantPickerProps> = ({ forceOpen = false, onClose 
                     {tenant.name}
                   </span>
                   <span className="mt-1 block text-sm text-slate-500">
-                    Role: {ROLE_LABELS[tenant.role] ?? tenant.role}
+                    {t('Role')}: {ROLE_LABELS[tenant.role] ?? tenant.role}
                   </span>
                   <span className="mt-1 block text-xs uppercase tracking-wide text-slate-400">
                     {tenant.code || '—'}
                   </span>
                 </span>
                 <span className="text-sm font-medium text-indigo-600">
-                  {isPending ? 'Switching…' : 'Switch'}
+                  {isPending
+                    ? t('Switching…')
+                    : isActive
+                      ? t('In use')
+                      : t('Switch')}
                 </span>
               </button>
             );
           })}
         </div>
+        {!hasMultipleClinics && (
+          <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <p>{t('You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.')}</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -285,3 +285,11 @@ Select a staff member,Select a staff member,Select a staff member
 Removing…,Removing…,Removing…
 Remove,Remove,Remove
 Global roles linked to this clinic,Global roles linked to this clinic,Global roles linked to this clinic
+Close,Close,Close
+Choose your clinic,Choose your clinic,Choose your clinic
+Select which clinic you would like to work in for this session.,Select which clinic you would like to work in for this session.,Select which clinic you would like to work in for this session.
+Role,Role,Role
+Switching…,Switching…,Switching…
+Switch,Switch,Switch
+In use,In use,In use
+You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.,You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.,You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.


### PR DESCRIPTION
## Summary
- allow the clinic selector card to open whenever at least one clinic is available and keep it static otherwise
- enhance the tenant picker to localize its copy, disable switching to the active clinic, and show guidance when only one clinic exists
- add translation entries for the new tenant picker strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e37fe64d88832ea5ab4288b21f4cd2