### PR TITLE
Display clinic context on patient and visit detail pages

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -91,6 +91,16 @@ export function removeTenantMember(tenantId: string, userId: string): Promise<vo
   }).then(() => undefined);
 }
 
+export interface ClinicSummary {
+  tenantId: string;
+  name: string;
+  code: string | null;
+}
+
+export interface ClinicAssignment extends ClinicSummary {
+  mrn: string | null;
+}
+
 export interface Patient {
   patientId: string;
   name: string;
@@ -99,6 +109,7 @@ export interface Patient {
   gender?: string | null;
   contact?: string | null;
   drugAllergies?: string | null;
+  clinics?: ClinicAssignment[];
 }
 
 export interface Doctor {
@@ -245,6 +256,7 @@ export interface Visit {
   department: string;
   reason?: string;
   doctor: Doctor;
+  clinic?: ClinicSummary;
 }
 
 export interface VisitSummary {
@@ -255,6 +267,7 @@ export interface VisitSummary {
   medications: Medication[];
   labResults: VisitLabResult[];
   observations: Observation[];
+  clinic?: ClinicSummary;
 }
 
 export interface PatientSummary extends Patient {

--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -293,3 +293,6 @@ Switching…,Switching…,Switching…
 Switch,Switch,Switch
 In use,In use,In use
 You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.,You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.,You only have access to one clinic right now. Ask your administrator to add you to more clinics to switch between locations.
+Clinic,Clinic,Clinic
+Clinic memberships,Clinic memberships,Clinic memberships
+MRN,MRN,MRN

--- a/client/src/pages/VisitDetail.tsx
+++ b/client/src/pages/VisitDetail.tsx
@@ -147,8 +147,12 @@ export default function VisitDetail() {
     </div>
   ) : undefined;
 
+  const clinicLabel = visit?.clinic
+    ? `${visit.clinic.name}${visit.clinic.code ? ` (${visit.clinic.code})` : ''}`
+    : null;
+
   const subtitle = visit
-    ? `Visit on ${formatDate(visit.visitDate)} with ${visit.doctor.name}`
+    ? `Visit on ${formatDate(visit.visitDate)}${clinicLabel ? ` at ${clinicLabel}` : ''} with ${visit.doctor.name}`
     : loading
       ? 'Loading visit details...'
       : error ?? 'Visit details unavailable.';
@@ -232,6 +236,11 @@ export default function VisitDetail() {
                   {visit.reason || 'No visit reason documented.'}
                 </p>
                 <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium">
+                  {clinicLabel && (
+                    <span className="inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-indigo-600">
+                      {clinicLabel}
+                    </span>
+                  )}
                   <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-blue-600">
                     {visit.department}
                   </span>
@@ -262,6 +271,10 @@ export default function VisitDetail() {
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-gray-500">Gender</dt>
                     <dd className="font-semibold text-gray-900">{gender}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <dt className="text-gray-500">Clinic</dt>
+                    <dd className="font-semibold text-gray-900">{clinicLabel ?? '—'}</dd>
                   </div>
                   <div className="flex items-center justify-between gap-4">
                     <dt className="text-gray-500">Insurance</dt>


### PR DESCRIPTION
## Summary
- expose clinic metadata with patient and visit API responses and update shared client types
- surface clinic assignments and MRNs within the patient profile, including visit list badges
- highlight visit clinic context in the visit detail header and patient snapshot

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c9c51b20832e966dc8bd1493b814