### PR TITLE
Ensure visit creation from appointments preserves tenant context

### DIFF
--- a/src/routes/appointments.ts
+++ b/src/routes/appointments.ts
@@ -379,11 +379,17 @@ router.patch(
             updatedAppointment.date.toISOString().slice(0, 10)
           );
 
+          const tenantId = updatedAppointment.tenantId;
+          if (!tenantId) {
+            throw new Error('Appointment is missing tenant context');
+          }
+
           const existingVisit = await client.visit.findFirst({
             where: {
               patientId: updatedAppointment.patientId,
               doctorId: updatedAppointment.doctorId,
               visitDate: appointmentDate,
+              tenantId,
             },
             select: { visitId: true },
           });
@@ -399,6 +405,7 @@ router.patch(
               visitDate: appointmentDate,
               department: updatedAppointment.department,
               reason: updatedAppointment.reason ?? undefined,
+              tenantId,
             },
             select: { visitId: true },
           });


### PR DESCRIPTION
## Summary
- ensure visits auto-created during appointment completion inherit the appointment tenant id
- guard against missing tenant context and scope existing visit lookups by tenant to avoid cross-tenant leaks

## Testing
- npm test -- --runTestsByPath tests/appointments.test.ts *(fails: environment is missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ccd34068832ebd8cdaa28bca5e9a