### PR TITLE
Add authenticated invoice printing with preview and formats

### DIFF
--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -85,3 +85,39 @@ export async function fetchJSON(
   }
   return response.json();
 }
+
+export async function fetchText(path: string, options: RequestInit = {}, retry = true) {
+  const headers = new Headers(options.headers || {});
+  if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`);
+
+  const response = await fetch(`/api${path}`, { ...options, headers });
+
+  if (response.status === 401 && retry) {
+    const refreshRes = await fetch('/api/auth/token/refresh', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (refreshRes.ok) {
+      const refreshData = await refreshRes.json();
+      setAccessToken(refreshData.accessToken);
+      headers.set('Authorization', `Bearer ${refreshData.accessToken}`);
+      const retryRes = await fetch(`/api${path}`, { ...options, headers });
+      if (!retryRes.ok) {
+        const message = await parseErrorMessage(retryRes);
+        throw new HttpError(retryRes.status, message || retryRes.statusText);
+      }
+      return retryRes.text();
+    }
+    setAccessToken(null);
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      setAccessToken(null);
+    }
+    const message = await parseErrorMessage(response);
+    throw new HttpError(response.status, message || response.statusText);
+  }
+
+  return response.text();
+}


### PR DESCRIPTION
## Summary
- add an authenticated `fetchText` helper for downloading HTML resources
- replace the visit billing print action with a printer selection modal and embedded preview
- render invoice receipts with B5 and thermal specific layouts based on the requested format

## Testing
- npm run lint *(fails: ESLint couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68e48d34b69c832e9eda819f7ea20a2d