### PR TITLE
Allow IT admins to manage clinic branding

### DIFF
--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -95,10 +95,16 @@ router.get('/clinic', requireTenantRoles(), async (req: AuthRequest, res: Respon
 
 router.patch(
   '/clinic',
-  requireRole('SystemAdmin', 'SuperAdmin'),
+  requireRole('SystemAdmin', 'SuperAdmin', 'ITAdmin'),
   requireTenantRoles(),
   async (req: AuthRequest, res: Response) => {
-    if (req.user?.role !== 'SystemAdmin' && req.user?.role !== 'SuperAdmin') {
+    const userRole = req.user?.role;
+    const tenantRole = req.tenantRole;
+
+    const isSystemOrSuperAdmin = userRole === 'SystemAdmin' || userRole === 'SuperAdmin';
+    const isAssignedItAdmin = userRole === 'ITAdmin' && tenantRole === 'ITAdmin';
+
+    if (!isSystemOrSuperAdmin && !isAssignedItAdmin) {
       return res.status(403).json({ error: 'Forbidden' });
     }
 


### PR DESCRIPTION
## Summary
- allow IT administrators assigned to a tenant to update branding and portal settings
- expand clinic configuration tests to cover assigned and unassigned IT administrator scenarios

## Testing
- `npm test -- tests/settings.test.ts` *(fails: DATABASE_URL must include sslmode=require / no test database available)*

------
https://chatgpt.com/codex/tasks/task_e_68e4966e5bb4832e90ec56df9c90b3ff