### PR TITLE
Allow IT admins to manage branding settings

### DIFF
--- a/client/src/i18n/translations.csv
+++ b/client/src/i18n/translations.csv
@@ -232,7 +232,7 @@ Unit cost,Unit cost,ယူနစ်စျေးနှုန်း
 Stock recorded successfully.,Stock recorded successfully.,စတော့မှတ်တမ်းတင်ပြီးပါပြီ။
 Saving…,Saving…,သိမ်းဆည်းနေပါသည်...
 Save Changes,Save Changes,ပြင်ဆင်ချက်များကို သိမ်းဆည်းပါ
-Only system administrators can update branding details.,Only system administrators can update branding details.,စနစ် အုပ်ချုပ်ရေးမှူးများသာ တံဆိပ် အချက်အလက်များကို ပြင်ဆင်ခွင့်ရှိသည်။
+Only system or IT administrators can update branding details.,Only system or IT administrators can update branding details.,စနစ် အုပ်ချုပ်ရေးမှူးများ သို့မဟုတ် IT အုပ်ချုပ်ရေးမှူးများသာ တံဆိပ် အချက်အလက်များကို ပြင်ဆင်ခွင့်ရှိသည်။
 Branding updated.,Branding updated.,တံဆိပ် အချက်အလက်များကို ပြင်ဆင်ပြီးပါပြီ။
 Unable to update branding.,Unable to update branding.,တံဆိပ် အချက်အလက်များကို ပြင်ဆင်၍မရနိုင်ပါ။
 Record stock,Record stock,စတော့ကို မှတ်တမ်းတင်ပါ

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -147,6 +147,7 @@ export default function Settings() {
   const latestDoctor = totalDoctors > 0 ? doctors[totalDoctors - 1] : undefined;
   const latestUser = totalUsers > 0 ? users[totalUsers - 1] : undefined;
   const isSystemAdmin = user?.role === 'SystemAdmin' || user?.role === 'SuperAdmin';
+  const canManageBranding = isSystemAdmin || user?.role === 'ITAdmin';
   const hasActiveTenant = Boolean(activeTenant);
   const canManageMultipleClinics =
     (tenants.length > 1 || (!activeTenant && tenants.length > 0)) &&
@@ -308,7 +309,7 @@ export default function Settings() {
 
   async function handleLogoChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
-    if (!file || !isSystemAdmin) return;
+    if (!file || !canManageBranding) return;
 
     if (!hasActiveTenant) {
       setBrandingError(t('Select a clinic before updating branding.'));
@@ -338,7 +339,7 @@ export default function Settings() {
 
   async function handleSave(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!isSystemAdmin) return;
+    if (!canManageBranding) return;
 
     if (!hasActiveTenant) {
       setBrandingError(t('Select a clinic before updating branding.'));
@@ -731,9 +732,9 @@ export default function Settings() {
                   <p className="mt-1 text-sm text-gray-600">
                     Update your organization name, upload a logo, and manage the patient widget visibility.
                   </p>
-                  {!isSystemAdmin && (
+                  {!canManageBranding && (
                     <p className="mt-2 text-xs font-semibold text-amber-600">
-                      {t('Only system administrators can update branding details.')}
+                      {t('Only system or IT administrators can update branding details.')}
                     </p>
                   )}
                 </div>
@@ -750,9 +751,9 @@ export default function Settings() {
                       type="text"
                       value={name}
                       onChange={(event) => setName(event.target.value)}
-                      disabled={!isSystemAdmin || brandingSaving || !hasActiveTenant}
+                      disabled={!canManageBranding || brandingSaving || !hasActiveTenant}
                       className={`mt-2 w-full rounded-xl border border-gray-200 px-4 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 ${
-                        !isSystemAdmin || !hasActiveTenant ? 'cursor-not-allowed opacity-60' : ''
+                        !canManageBranding || !hasActiveTenant ? 'cursor-not-allowed opacity-60' : ''
                       }`}
                     />
                   </div>
@@ -766,9 +767,9 @@ export default function Settings() {
                       type="file"
                       accept="image/*"
                       onChange={handleLogoChange}
-                      disabled={!isSystemAdmin || logoUploading || !hasActiveTenant}
+                      disabled={!canManageBranding || logoUploading || !hasActiveTenant}
                       className={`mt-2 block w-full text-sm text-gray-500 file:mr-4 file:rounded-full file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold ${
-                        !isSystemAdmin || !hasActiveTenant
+                        !canManageBranding || !hasActiveTenant
                           ? 'file:bg-gray-200 file:text-gray-500'
                           : 'file:bg-blue-50 file:text-blue-600 hover:file:bg-blue-100'
                       } ${logoUploading ? 'opacity-70' : ''}`}
@@ -805,10 +806,10 @@ export default function Settings() {
                     role="switch"
                     aria-checked={widgetEnabled}
                     onClick={() => {
-                      if (!isSystemAdmin || !hasActiveTenant) return;
+                      if (!canManageBranding || !hasActiveTenant) return;
                       setWidgetEnabled(!widgetEnabled);
                     }}
-                    disabled={!isSystemAdmin || !hasActiveTenant}
+                    disabled={!canManageBranding || !hasActiveTenant}
                     className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition ${
                       widgetEnabled ? 'bg-blue-600' : 'bg-gray-300'
                     }`}
@@ -825,9 +826,9 @@ export default function Settings() {
                 <div className="flex justify-end">
                   <button
                     type="submit"
-                    disabled={!isSystemAdmin || brandingSaving || !hasActiveTenant}
+                    disabled={!canManageBranding || brandingSaving || !hasActiveTenant}
                     className={`inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold text-white shadow ${
-                      !isSystemAdmin || !hasActiveTenant
+                      !canManageBranding || !hasActiveTenant
                         ? 'bg-gray-400'
                         : brandingSaving
                           ? 'bg-blue-400'


### PR DESCRIPTION
## Summary
- allow IT administrators to manage branding actions by recognizing their role alongside system administrators
- update the disabled states and explanatory copy to reflect the expanded branding permissions

## Testing
- npm run lint -- client/src/pages/Settings.tsx *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e49fae7624832ebc1cf14f4021aef5