### PR TITLE
Fix invoice scanner schema and PDF import

### DIFF
--- a/tests/services/invoiceScanner.test.ts
+++ b/tests/services/invoiceScanner.test.ts
@@ -66,6 +66,12 @@ describe('scanInvoice', () => {
     expect(invoiceError.message).toContain('not authorized');
     expect(invoiceError.details).toEqual({
       providerMessage: 'Incorrect API key provided',
+      debugContext: expect.objectContaining({
+        model: 'gpt-4o-mini',
+        mimeType: 'image/gif',
+        fileSize: buffer.length,
+        inputType: 'image',
+      }),
     });
   });
 });


### PR DESCRIPTION
## Summary
- import the pdf-parse implementation directly to avoid debug mode file lookups
- update the invoice extraction schema so every property is listed in the required array
- harden unauthorized error detection and refresh the unit test expectation for the debug context

## Testing
- npm test -- invoiceScanner *(fails: OpenAI SDK attempts a real network call when the jest mock is bypassed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f4db8e98832e9c7a74cda85cccb3