### PR TITLE
Add type declaration for pdf-parse import

### DIFF
--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,10 +1,8 @@
-declare module 'pdf-parse' {
-  interface PDFParseResult {
-    text?: string | null;
-  }
+declare module 'pdf-parse/lib/pdf-parse.js' {
+  import type { PDFData } from 'pdf-parse';
 
-  type PDFParse = (data: Buffer) => Promise<PDFParseResult>;
+  type PdfParse = (data: Buffer) => Promise<PDFData>;
 
-  const pdfParse: PDFParse;
-  export = pdfParse;
+  const pdfParse: PdfParse;
+  export default pdfParse;
 }


### PR DESCRIPTION
## Summary
- add a module declaration for the direct `pdf-parse` implementation import so TypeScript recognizes it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e617dc2d1c832eb03cf8ff6244ce66